### PR TITLE
Change post_deploy() hookspec definition to match existing usage in civic_band

### DIFF
--- a/src/clerk/hookspecs.py
+++ b/src/clerk/hookspecs.py
@@ -18,7 +18,7 @@ class ClerkSpec:
         """Deploys the necessary files for serving a municipality"""
 
     @hookspec
-    def post_deploy(self, subdomain):
+    def post_deploy(self, site):
         """Runs actions after the deploy of a municipality"""
 
     @hookspec


### PR DESCRIPTION
Was getting this error when attempting to first run civic-band:

```
mboyd@DESKTOP-2C3AUEJ /m/c/U/m/P/civic-band (main)> (civic-band) python civic.py -h                                                                                                                                                
Traceback (most recent call last):
  File "/mnt/c/Users/macha/PycharmProjects/civic-band/civic.py", line 41, in <module>
    pm.register(CivicBandPlugins())
  File "/home/mboyd/.virtualenvs/civic-band/lib/python3.12/site-packages/pluggy/_manager.py", line 168, in register
    self._verify_hook(hook, hookimpl)
  File "/home/mboyd/.virtualenvs/civic-band/lib/python3.12/site-packages/pluggy/_manager.py", line 343, in _verify_hook
    raise PluginValidationError(
pluggy._manager.PluginValidationError: Plugin '137730747430960' for hook 'post_deploy'
hookimpl definition: post_deploy(site)
Argument(s) {'site'} are declared in the hookimpl but can not be found in the hookspec
Sentry is attempting to send 2 pending events
Waiting up to 2 seconds
```

Checked, and there seemed to be a mismatch between how the hook was spec'd and implemented:


```
    @hookspec
    def post_deploy(self, subdomain):
```

vs (in the civic-band repo)
```
@hookimpl
    def post_deploy(self, site):
```

Since `subdomain` is itself one of the things being passed in as part of the `site` dictionary, `site` seems like the correct nomenclature.