### PR TITLE
Hotfix: Normalize postgres:// URLs to postgresql://

### DIFF
--- a/src/clerk/db.py
+++ b/src/clerk/db.py
@@ -25,6 +25,10 @@ def get_civic_db():
     database_url = os.getenv("DATABASE_URL")
 
     if database_url:
+        # Normalize postgres:// to postgresql:// for SQLAlchemy 1.4+
+        if database_url.startswith("postgres://"):
+            database_url = database_url.replace("postgres://", "postgresql://", 1)
+
         # Production: PostgreSQL
         try:
             engine = create_engine(


### PR DESCRIPTION
## Problem

SQLAlchemy 1.4+ requires `postgresql://` scheme but many managed database services (Heroku, Render, DigitalOcean, etc.) provide `postgres://` URLs, causing:

```
sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres
```

This blocks production deployment for users with managed PostgreSQL.

## Solution

Auto-normalize `postgres://` to `postgresql://` in `get_civic_db()` before passing to SQLAlchemy.

## Changes

- **src/clerk/db.py**: Add URL scheme normalization
- **tests/test_db.py**: Add test for normalization

## Testing

```bash
pytest tests/test_db.py::TestErrorHandling::test_postgres_url_normalized_to_postgresql
```

✅ Test passes

## Compatibility

Works with both URL formats:
- `postgresql://...` (modern SQLAlchemy)
- `postgres://...` (managed services) → auto-converted