### PR TITLE
Fix worker loading failures - remove --burst flag from LaunchAgent template

### DIFF
--- a/scripts/launchd-worker-template.plist
+++ b/scripts/launchd-worker-template.plist
@@ -9,7 +9,6 @@
         <string>{{CLERK_PATH}}</string>
         <string>worker</string>
         <string>{{WORKER_TYPE}}</string>
-        <string>--burst</string>
     </array>
     <key>WorkingDirectory</key>
     <string>{{WORKING_DIR}}</string>


### PR DESCRIPTION
## Problem
Workers were failing to load with "Failed to load" errors on production. The diagnostic output showed:
- All permissions correct
- Redis connection working
- Worker runs successfully when executed manually
- But LaunchAgents showed no running workers

## Root Cause
The plist template includes `--burst` flag, which makes workers exit immediately when the queue is empty. This is incompatible with LaunchAgents which expect long-running services.

When a LaunchAgent service exits too quickly after starting (even with exit code 0), launchd marks it as "Failed to load".

## Solution
Remove `--burst` from the plist template. Workers should run continuously, waiting for jobs to appear in the queue, not exit when the queue is empty.

## Testing
After this change, reinstall workers on production:
```bash
clerk uninstall-workers
clerk install-workers
launchctl list | grep com.civicband.clerk.worker
# Should now show PIDs instead of "-"
```

Fixes the issue identified in worker diagnostics where workers could run manually but failed to stay running as LaunchAgents.