### PR TITLE
Fix LaunchAgent PATH to include Homebrew binaries

### DIFF
--- a/scripts/install-workers.sh
+++ b/scripts/install-workers.sh
@@ -62,6 +62,17 @@ DATABASE_URL="${DATABASE_URL:-sqlite:///civic.db}"
 STORAGE_DIR="${STORAGE_DIR:-../sites}"
 DEFAULT_OCR_BACKEND="${DEFAULT_OCR_BACKEND:-tesseract}"
 
+# Detect architecture and set PATH for Homebrew + system binaries
+# LaunchAgents run with minimal PATH, need to include Homebrew paths for tools like pdfinfo
+ARCH=$(uname -m)
+if [ "$ARCH" = "arm64" ]; then
+    # Apple Silicon: Homebrew is in /opt/homebrew
+    PATH_VAR="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+else
+    # Intel: Homebrew is in /usr/local
+    PATH_VAR="/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
+fi
+
 # Get clerk executable path
 CLERK_PATH=$(which clerk || echo "")
 if [ -z "${CLERK_PATH}" ]; then
@@ -101,6 +112,7 @@ echo "  Redis URL: ${REDIS_URL}"
 echo "  Database URL: ${DATABASE_URL}"
 echo "  Storage dir: ${STORAGE_DIR}"
 echo "  OCR backend: ${DEFAULT_OCR_BACKEND}"
+echo "  PATH: ${PATH_VAR}"
 echo ""
 echo "Worker counts:"
 echo "  FETCH_WORKERS: ${FETCH_WORKERS}"
@@ -130,6 +142,7 @@ create_worker() {
         sed "s|{{DATABASE_URL}}|${DATABASE_URL}|g" | \
         sed "s|{{STORAGE_DIR}}|${STORAGE_DIR}|g" | \
         sed "s|{{DEFAULT_OCR_BACKEND}}|${DEFAULT_OCR_BACKEND}|g" | \
+        sed "s|{{PATH}}|${PATH_VAR}|g" | \
         sed "s|{{LOG_DIR}}|${LOG_DIR}|g" \
         > "${plist_file}"
 

--- a/scripts/launchd-worker-template.plist
+++ b/scripts/launchd-worker-template.plist
@@ -22,6 +22,8 @@
         <string>{{STORAGE_DIR}}</string>
         <key>DEFAULT_OCR_BACKEND</key>
         <string>{{DEFAULT_OCR_BACKEND}}</string>
+        <key>PATH</key>
+        <string>{{PATH}}</string>
     </dict>
     <key>StandardOutPath</key>
     <string>{{LOG_DIR}}/clerk-worker-{{WORKER_TYPE}}-{{WORKER_NUM}}.log</string>


### PR DESCRIPTION
## Summary

Fixes production error where OCR workers crash because `pdfinfo` command is not found.

**Error**:
```
FileNotFoundError: [Errno 2] No such file or directory: 'pdfinfo'
```

## Root Cause

LaunchAgents run with minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that does not include Homebrew binaries.

The `pdf2image` library (used for OCR) calls `pdfinfo` (from the `poppler` package) as a subprocess, but can't find it because:
- Apple Silicon: poppler is in `/opt/homebrew/bin/pdfinfo`
- Intel Mac: poppler is in `/usr/local/bin/pdfinfo`

Neither path is in the LaunchAgent's default PATH.

## Changes

### 1. LaunchAgent Template (`launchd-worker-template.plist`)
- Added `PATH` environment variable to `EnvironmentVariables` section

### 2. Install Script (`install-workers.sh`)
- Detects architecture using `uname -m`
- Sets appropriate PATH:
  - **Apple Silicon**: `/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`
  - **Intel**: `/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin`
- Substitutes `{{PATH}}` placeholder in plist template
- Shows PATH in configuration output

## Deployment Instructions

After merging:

```bash
cd /path/to/clerk

# Pull latest changes
git pull

# Reinstall workers to apply new PATH
scripts/uninstall-workers.sh
scripts/install-workers.sh

# Verify workers restarted
launchctl list | grep com.civicband.clerk.worker
```

## Test Plan

- [ ] Code changes committed
- [ ] Deploy to production
- [ ] Run `scripts/uninstall-workers.sh` then `scripts/install-workers.sh`
- [ ] Trigger an OCR job
- [ ] Verify no more `pdfinfo` FileNotFoundError
- [ ] Check OCR completes successfully