### PR TITLE
Fix OCR txt directory creation for agendas and minutes

### DIFF
--- a/src/clerk/fetcher.py
+++ b/src/clerk/fetcher.py
@@ -631,6 +631,7 @@ class Fetcher:
         try:
             doc_path = f"{self.dir_prefix}{prefix}/pdfs/{meeting}/{date}.pdf"
             doc_image_dir_path = f"{self.dir_prefix}{prefix}/images/{meeting}/{date}"
+            doc_txt_dir_path = f"{self.dir_prefix}{prefix}/txt/{meeting}/{date}"
 
             # Backend tracking at start of processing
             log(
@@ -664,6 +665,10 @@ class Fetcher:
             # Create images directory if it doesn't exist
             # Handles both minutes (no prefix) and agendas (prefix="/_agendas")
             os.makedirs(doc_image_dir_path, exist_ok=True)
+
+            # Create txt directory if it doesn't exist
+            # Handles both minutes (no prefix) and agendas (prefix="/_agendas")
+            os.makedirs(doc_txt_dir_path, exist_ok=True)
 
             try:
                 for chunk_start in range(1, total_pages + 1, PDF_CHUNK_SIZE):
@@ -703,7 +708,7 @@ class Fetcher:
                 page_image_path = f"{doc_image_dir_path}/{page_image}"
                 remote_storage_path = f"/{self.subdomain}{prefix}/{meeting}/{date}/{page_image}"
                 txt_filename = page_image.replace(".png", ".txt")
-                txt_filepath = f"{self.dir_prefix}{prefix}/txt/{meeting}/{date}/{txt_filename}"
+                txt_filepath = f"{doc_txt_dir_path}/{txt_filename}"
 
                 if not os.path.exists(txt_filepath):
                     try:


### PR DESCRIPTION
## Summary

- Fix `FileNotFoundError` when saving OCR text output for agenda PDFs
- Create txt directory before writing text files
- Follows same pattern as PR #54 which fixed image directory creation

## Root Cause

**Error seen in production**:
```
[Errno 2] No such file or directory: '/Volumes/CivicBandData/sites/alameda.ca/_agendas/txt/SocialServiceHumanRelationsBoard/2026-01-15/1.txt'
```

`do_ocr_job()` tries to write txt files without creating the parent directory first.

## Fix

Added `os.makedirs(doc_txt_dir_path, exist_ok=True)` before the OCR loop, matching the fix for images in PR #54:

**Before**:
- Line 666: `os.makedirs(doc_image_dir_path, exist_ok=True)` ✅ Images
- No directory creation for txt ❌

**After**:
- Line 666: `os.makedirs(doc_image_dir_path, exist_ok=True)` ✅ Images  
- Line 670: `os.makedirs(doc_txt_dir_path, exist_ok=True)` ✅ Txt

## Test Plan

- [x] All 31 fetcher tests pass
- [x] Pattern matches successful PR #54 fix
- [ ] Verify in production: OCR jobs complete without txt directory errors
- [ ] Monitor logs for FileNotFoundError elimination

## Related

- Fixes production errors seen in OCR worker logs on 2026-01-15
- Completes the directory creation fix started in PR #54