### PR TITLE
fix: Wrap SELECT 1 query with text() in health check

### DIFF
--- a/src/clerk/cli.py
+++ b/src/clerk/cli.py
@@ -1835,9 +1835,11 @@ def health(output_json, verbose):
 
     # Check 2: PostgreSQL connectivity
     try:
+        from sqlalchemy import text
+
         with civic_db_connection() as conn:
             # Simple query to verify connection
-            result = conn.execute("SELECT 1").fetchone()
+            result = conn.execute(text("SELECT 1")).fetchone()
             if result:
                 health_status["checks"]["database"] = {
                     "status": "ok",


### PR DESCRIPTION
## Issue

The `clerk health` command was failing with: `Not an executable object: 'SELECT 1'`

## Fix

SQLAlchemy 2.0+ requires `text()` wrapper for raw SQL queries.

Changed:
```python
result = conn.execute("SELECT 1").fetchone()
```

To:
```python
from sqlalchemy import text
result = conn.execute(text("SELECT 1")).fetchone()
```

## Testing

```bash
uv run clerk health
```

Should now properly check PostgreSQL connectivity.
