### PR TITLE
fix: Use timezone-aware datetime in health check site progress

### DIFF
--- a/src/clerk/cli.py
+++ b/src/clerk/cli.py
@@ -20,6 +20,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # ruff: noqa: E402
+from datetime import UTC
+
 from . import output
 from .output import log
 from .plugin_loader import load_plugins_from_directory
@@ -1978,7 +1980,7 @@ def health(output_json, verbose):
                             "subdomain": row[0],
                             "stage": row[1],
                             "progress": f"{row[2]}/{row[3]}" if row[3] else "unknown",
-                            "stalled_for": str(datetime.now() - row[4]) if row[4] else "unknown",
+                            "stalled_for": str(datetime.now(UTC) - row[4]) if row[4] else "unknown",
                         }
                     )
 


### PR DESCRIPTION
## Issue

The `clerk health` command was showing a warning:
```
⚠️  WARNINGS:
  • Cannot check site progress: can't subtract offset-naive and offset-aware datetimes
```

## Root Cause

The code was comparing `datetime.now()` (naive/no timezone) with PostgreSQL's `updated_at` timestamp (timezone-aware), causing a TypeError.

## Fix

Changed:
```python
"stalled_for": str(datetime.now() - row[4]) if row[4] else "unknown"
```

To:
```python
"stalled_for": str(datetime.now(UTC) - row[4]) if row[4] else "unknown"
```

Now both datetimes are timezone-aware (UTC), allowing proper subtraction.

## Testing

Run `clerk health` - the site progress warning should be gone and stuck sites will be properly detected.
