### PR TITLE
feat: Show stuck site details in verbose health check output

### DIFF
--- a/src/clerk/cli.py
+++ b/src/clerk/cli.py
@@ -2063,6 +2063,12 @@ def health(output_json, verbose):
 
             elif check_name == "site_progress" and check_data.get("stuck_sites", 0) > 0:
                 click.echo(f"    Stuck sites: {check_data['stuck_sites']}")
+                if verbose and "details" in check_data:
+                    for site in check_data["details"]:
+                        click.echo(
+                            f"      • {site['subdomain']}: {site['stage']} ({site['progress']}) "
+                            f"- stalled {site['stalled_for']} [status: {site['status']}]"
+                        )
 
         # Show issues
         if health_status["issues"]:


### PR DESCRIPTION
## Enhancement

When running `clerk health --verbose`, the command now shows detailed information about each stuck site instead of just the count.

## What's Displayed

For each stuck site:
- **Subdomain**: Which site is stuck
- **Stage**: What pipeline stage it's in (fetch, ocr, compilation, deploy)
- **Progress**: Completed/total (e.g., "45/70" pages OCR'd)
- **Stalled Duration**: How long it's been stuck
- **Status**: Deployment status from sites table

## Example Output

Before:
```
! Site Progress: warning
    Stuck sites: 10
```

After (with `--verbose`):
```
! Site Progress: warning
    Stuck sites: 10
      • alameda.civic.band: ocr (45/70) - stalled 3:25:12 [status: needs_ocr]
      • berkeley.civic.band: compilation (0/1) - stalled 2:15:45 [status: needs_deploy]
      ...
```

## Use Case

This helps operators quickly identify:
- Which specific sites need attention
- What stage they're failing at
- Whether it's a single site issue or systemic problem

## Testing

```bash
clerk health --verbose
```
