### PR TITLE
Add Sentry environment variables to worker LaunchAgents

### DIFF
--- a/scripts/install-workers.sh
+++ b/scripts/install-workers.sh
@@ -63,6 +63,9 @@ DATABASE_URL="${DATABASE_URL:-sqlite:///civic.db}"
 STORAGE_DIR="${STORAGE_DIR:-../sites}"
 DEFAULT_OCR_BACKEND="${DEFAULT_OCR_BACKEND:-tesseract}"
 LOKI_URL="${LOKI_URL:-}"  # Optional - empty string if not set
+SENTRY_DSN="${SENTRY_DSN:-}"  # Optional - empty string if not set
+SENTRY_ENVIRONMENT="${SENTRY_ENVIRONMENT:-production}"
+SENTRY_TRACES_SAMPLE_RATE="${SENTRY_TRACES_SAMPLE_RATE:-0.0}"
 
 # Detect architecture and set PATH for Homebrew + system binaries
 # LaunchAgents run with minimal PATH, need to include Homebrew paths for tools like pdfinfo
@@ -115,6 +118,9 @@ echo "  Database URL: ${DATABASE_URL}"
 echo "  Storage dir: ${STORAGE_DIR}"
 echo "  OCR backend: ${DEFAULT_OCR_BACKEND}"
 echo "  LOKI_URL: ${LOKI_URL:-not set}"
+echo "  SENTRY_DSN: ${SENTRY_DSN:-not set}"
+echo "  SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT}"
+echo "  SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE}"
 echo "  PATH: ${PATH_VAR}"
 echo ""
 echo "Worker counts:"
@@ -148,6 +154,9 @@ create_worker() {
         sed "s|{{DEFAULT_OCR_BACKEND}}|${DEFAULT_OCR_BACKEND}|g" | \
         sed "s|{{PATH}}|${PATH_VAR}|g" | \
         sed "s|{{LOKI_URL}}|${LOKI_URL}|g" | \
+        sed "s|{{SENTRY_DSN}}|${SENTRY_DSN}|g" | \
+        sed "s|{{SENTRY_ENVIRONMENT}}|${SENTRY_ENVIRONMENT}|g" | \
+        sed "s|{{SENTRY_TRACES_SAMPLE_RATE}}|${SENTRY_TRACES_SAMPLE_RATE}|g" | \
         sed "s|{{LOG_DIR}}|${LOG_DIR}|g" \
         > "${plist_file}"
 

--- a/scripts/launchd-worker-template.plist
+++ b/scripts/launchd-worker-template.plist
@@ -26,6 +26,12 @@
         <string>{{PATH}}</string>
         <key>LOKI_URL</key>
         <string>{{LOKI_URL}}</string>
+        <key>SENTRY_DSN</key>
+        <string>{{SENTRY_DSN}}</string>
+        <key>SENTRY_ENVIRONMENT</key>
+        <string>{{SENTRY_ENVIRONMENT}}</string>
+        <key>SENTRY_TRACES_SAMPLE_RATE</key>
+        <string>{{SENTRY_TRACES_SAMPLE_RATE}}</string>
     </dict>
     <key>StandardOutPath</key>
     <string>{{LOG_DIR}}/clerk-worker-{{WORKER_TYPE}}-{{WORKER_NUM}}.log</string>


### PR DESCRIPTION
## Summary

Adds Sentry environment variables to worker LaunchAgent configuration so that workers can send error reports to Sentry.

## Changes

- **LaunchAgent template**: Add `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_TRACES_SAMPLE_RATE` to environment variables
- **install-workers.sh**: Set default values and add sed replacements to populate from `.env`
- **Output**: Show Sentry configuration during installation

## Configuration

After merging, workers will automatically pick up Sentry configuration from `.env`:

```bash
# Add to .env (already merged in PR #75)
SENTRY_DSN="https://11ecb14e4a3249129b039b57090320c1@andromeda.nebulosa-moth.ts.net/3"
SENTRY_ENVIRONMENT="production"
SENTRY_TRACES_SAMPLE_RATE="0.0"
```

## Why This Matters

Currently, the 1303 OCR job failures show **(No exception info available)** because:
1. Sentry is capturing the exceptions from workers
2. But RQ's `exc_info` field isn't being populated

With this change:
- Workers will have access to Sentry configuration
- Exceptions from worker jobs will be tracked in Sentry
- We can debug the OCR failures (mesa.az PDFs, etc.)

## Deployment Steps

After merging:

1. **Add Sentry config to `.env`** on magmell (if not already there)
2. **Reinstall workers** to pick up new environment variables:
   ```bash
   cd ~/civicband/civic-band
   uv run clerk uninstall-workers
   uv run clerk install-workers
   ```
3. **Verify** workers have Sentry vars:
   ```bash
   # Check a worker plist file
   cat ~/Library/LaunchAgents/com.civicband.clerk.worker.ocr.1.plist | grep SENTRY
   ```

## Test Plan

- [ ] Merge PR
- [ ] Add SENTRY_DSN to .env on production
- [ ] Reinstall workers
- [ ] Verify plist files contain Sentry environment variables
- [ ] Trigger a failing OCR job
- [ ] Check Sentry dashboard for exception