### PR TITLE
Fix Sentry RQ integration to capture worker exceptions

### DIFF
--- a/src/clerk/sentry.py
+++ b/src/clerk/sentry.py
@@ -30,12 +30,15 @@ def init_sentry():
     environment = os.getenv("SENTRY_ENVIRONMENT", "production")
     traces_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
 
+    # Import RQ integration to capture worker job exceptions
+    from sentry_sdk.integrations.rq import RqIntegration
+
     sentry_sdk.init(
         dsn=sentry_dsn,
         environment=environment,
         send_default_pii=True,
         max_request_body_size="always",
         traces_sample_rate=traces_sample_rate,
-        # Capture exception info for RQ jobs
-        integrations=[],
+        # Enable RQ integration to capture worker job exceptions
+        integrations=[RqIntegration()],
     )


### PR DESCRIPTION
## Summary

Fixes the Sentry RQ integration that was broken by passing an empty `integrations=[]` list. This was preventing Sentry from capturing RQ worker job exceptions.

## The Problem

When we added Sentry in PR #75, we passed `integrations=[]` which **disabled all automatic integrations**, including the RQ integration. This meant:

- Worker job exceptions were NOT being sent to Sentry
- Failed jobs showed **(No exception info available)** in `clerk check-failed` output  
- We couldn't debug the 1303 OCR failures

## The Fix

Explicitly enable `RqIntegration()` so that RQ worker job exceptions are captured and sent to Sentry.

```python
from sentry_sdk.integrations.rq import RqIntegration

sentry_sdk.init(
    dsn=sentry_dsn,
    environment=environment,
    send_default_pii=True,
    max_request_body_size="always",
    traces_sample_rate=traces_sample_rate,
    integrations=[RqIntegration()],  # ← Fixed!
)
```

## Testing

Test error confirmed Sentry is working on magmell:

```bash
# On magmell
cd ~/civicband/civic-band
uv run python /tmp/test_sentry.py
# ✅ Error appeared in bugsink dashboard
```

## After Merging

On magmell:

```bash
cd ~/civicband/civic-band
git pull
uv run clerk uninstall-workers
uv run clerk install-workers
```

Then trigger a failing job and check bugsink - the error should now appear with full stack trace!

## Expected Outcome

After this fix + restarting workers:
- RQ worker job exceptions will be sent to Sentry/bugsink
- Failed OCR jobs will show full stack traces in bugsink
- We can finally debug the 1303 OCR failures (mesa.az, etc.)
- `clerk check-failed` might also start showing `exc_info` (if RQ stores it)