### PR TITLE
Fix: Count OCR documents instead of pages in migration

### DIFF
--- a/src/clerk/migrations.py
+++ b/src/clerk/migrations.py
@@ -242,7 +242,9 @@ def recover_stuck_site(subdomain: str) -> bool:
 
             # Atomic claim to prevent duplicate coordinators
             if claim_coordinator_enqueue(subdomain):
-                click.echo(f"  {subdomain}: Found {completed_docs} completed documents, enqueueing coordinator")
+                click.echo(
+                    f"  {subdomain}: Found {completed_docs} completed documents, enqueueing coordinator"
+                )
 
                 # Enqueue coordinator
                 get_compilation_queue().enqueue(
@@ -258,7 +260,9 @@ def recover_stuck_site(subdomain: str) -> bool:
                 return False
 
         elif completed_docs == 0:
-            click.secho(f"  {subdomain}: No completed OCR documents found - ALL OCR failed", fg="yellow")
+            click.secho(
+                f"  {subdomain}: No completed OCR documents found - ALL OCR failed", fg="yellow"
+            )
             return False
 
         else:


### PR DESCRIPTION
## Problem

The migration was mixing units when counting OCR progress:
- `ocr_total` = PDF count (documents) ✅
- `ocr_completed` = txt file count (pages) ❌

This broke the coordinator trigger logic: `(completed + failed) == total`

**Example of the bug:**
- Site has 10 PDFs that generated 50 txt files (5 pages each)
- Buggy logic: `ocr_total=10, ocr_completed=50` → 50 ≠ 10 → coordinator never triggers
- Correct logic: `ocr_total=10, ocr_completed=10` → 10 = 10 → coordinator triggers

## Root Cause

OCR jobs operate at the document level:
- 1 PDF document → 1 OCR job → multiple txt files (one per page)
- Directory structure: `txt/{meeting}/{date}/*.txt`
- One directory per document, multiple txt files per document

The old `count_txt_files()` used `glob("**/*.txt")` which counted pages, not documents.

## Solution

Changed `count_txt_files()` to count document directories with txt files:

```python
# Old (buggy) - counts pages
return len(list(txt_dir.glob("**/*.txt")))

# New (fixed) - counts documents
for meeting_dir in txt_base.iterdir():
    for doc_dir in meeting_dir.iterdir():
        if list(doc_dir.glob("*.txt")):
            completed_docs += 1
```

Now both counters use document-level units consistently.

## Changes

- Updated `count_txt_files()` to count document directories, not individual txt files
- Renamed variables (`txt_count` → `completed_docs`) for clarity
- Updated log messages to reflect document-level tracking
- Added comprehensive documentation explaining document vs page distinction
- Kept the sanity check (`ocr_total >= ocr_completed`) for edge cases

## Testing

This fix ensures:
- `ocr_completed` <= `ocr_total` for all sites (documents ≤ documents)
- Coordinator trigger logic works correctly: `(completed + failed) == total`
- Migration dry-run shows sensible counts

## Impact

This is a critical fix for the migration. Without it:
- Sites with completed OCR would show `ocr_completed > ocr_total`
- Coordinators would never trigger
- Pipeline would remain stuck even after migration