### PR TITLE
Fix: Use correct stage name in db_compilation_job

### DIFF
--- a/src/clerk/workers.py
+++ b/src/clerk/workers.py
@@ -762,8 +762,8 @@ def db_compilation_job(subdomain, run_id=None, extract_entities=False, ignore_ca
 
         # Update progress counter
         with civic_db_connection() as conn:
-            update_site_progress(conn, subdomain, stage="extraction", stage_total=len(txt_files))
-        logger.debug("Updated extraction progress with %d total files", len(txt_files))
+            update_site_progress(conn, subdomain, stage="compilation", stage_total=len(txt_files))
+        logger.debug("Updated compilation progress with %d total files", len(txt_files))
 
         # Build database
         log_with_context(


### PR DESCRIPTION
## Summary

Fixed incorrect stage name in `db_compilation_job()` progress tracking. Changed from `"extraction"` to `"compilation"` to accurately reflect the current pipeline stage.

## Problem

The `db_compilation_job()` function was updating progress with `stage="extraction"` (line 765), which is incorrect. This job is part of the compilation stage, not the extraction stage.

## Solution

- Changed `update_site_progress(conn, subdomain, stage="extraction", ...)` to `stage="compilation"`
- Updated logger message for consistency

## Architecture Context

The pipeline architecture separates extraction from the core flow:

- **Core pipeline**: `fetch → OCR → compilation → deploy`
  - Uses `extract_entities=False` (uses cached entities if available, empty if not)
  - This is the fast path for initial deployment

- **Separate extraction flow**: `extraction_job → compilation (with entities) → deploy`
  - Can run independently for sites that need entity extraction
  - Typically runs after a site has been successfully deployed once

This fix ensures progress tracking correctly reflects which stage is running.

## Testing

- All 311 tests pass
- No test changes needed (tests don't assert on stage name)