### PR TITLE
Fix: Correct stage tracking for compilation flow

### DIFF
--- a/scripts/fix_extraction_stage.py
+++ b/scripts/fix_extraction_stage.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Fix sites stuck at 'extraction' stage but already deployed.
+
+This script:
+1. Finds sites with current_stage='extraction' but status='deployed'
+2. Updates their current_stage to 'completed'
+3. This fixes a bug where ocr_complete_coordinator set stage to 'extraction'
+   but deploy_job didn't update sites.current_stage to 'completed'
+"""
+
+import click
+from sqlalchemy import select, update
+
+from clerk.db import civic_db_connection
+from clerk.models import sites_table
+
+
+def fix_extraction_stage(dry_run=False):
+    """Fix sites stuck at extraction stage."""
+
+    with civic_db_connection() as conn:
+        # Find sites stuck at extraction but actually deployed
+        stuck = conn.execute(
+            select(sites_table).where(
+                sites_table.c.current_stage == "extraction",
+                sites_table.c.status == "deployed",
+            )
+        ).fetchall()
+
+        click.echo(f"Found {len(stuck)} sites stuck at 'extraction' stage but deployed")
+        click.echo()
+
+        fixed = 0
+        for site in stuck:
+            subdomain = site.subdomain
+            status = site.status
+
+            click.echo(f"  {subdomain}: status={status}, current_stage=extraction → completed")
+
+            # Update current_stage to completed (skip in dry-run mode)
+            if not dry_run:
+                conn.execute(
+                    update(sites_table)
+                    .where(sites_table.c.subdomain == subdomain)
+                    .values(current_stage="completed")
+                )
+
+            fixed += 1
+
+        click.echo()
+        click.echo(f"Fixed {fixed} sites")
+
+
+@click.command()
+@click.option(
+    "--dry-run", is_flag=True, default=False, help="Show what would be done without making changes"
+)
+def main(dry_run):
+    """Fix sites stuck at extraction stage but already deployed."""
+
+    click.echo("=" * 80)
+    click.echo("FIX: Sites stuck at 'extraction' stage but deployed")
+    click.echo("=" * 80)
+    click.echo()
+
+    if dry_run:
+        click.secho("DRY RUN MODE - no changes will be made", fg="yellow")
+        click.echo()
+
+    fix_extraction_stage(dry_run=dry_run)
+
+    if not dry_run:
+        click.echo()
+        click.secho("Migration complete!", fg="green")
+    else:
+        click.echo()
+        click.secho("Dry run complete - run without --dry-run to apply changes", fg="yellow")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -613,7 +613,7 @@ def test_coordinator_resets_enqueued_flag(mock_site, tmp_path, monkeypatch, mock
             select(sites_table).where(sites_table.c.subdomain == subdomain)
         ).fetchone()
 
-    assert site.current_stage == "extraction"  # Moved to next stage
+    assert site.current_stage == "compilation"  # Moved to compilation stage
     assert site.coordinator_enqueued is False  # Flag reset
     assert site.compilation_total == 1  # Next stage initialized
     assert site.extraction_total == 1


### PR DESCRIPTION
## Summary

Fixes incorrect stage tracking where sites were marked as "extraction" instead of "compilation" and were never updated to "completed" after deployment.

## Problem

Found 400 sites with `current_stage="extraction"` but `status="deployed"`, indicating they completed the pipeline successfully but stage tracking was incorrect.

**Root causes:**

1. **ocr_complete_coordinator** (line 624) set `current_stage="extraction"` even though it immediately enqueued the compilation job (Path 1 - core pipeline without extraction)
2. **deploy_job** updated `site_progress_table.current_stage = "completed"` but never updated `sites.current_stage`

This created a mismatch where:
- `site_progress_table.current_stage = "completed"` ✓
- `sites.current_stage = "extraction"` ✗ (stuck forever)
- `sites.status = "deployed"` ✓

## Solution

1. **ocr_complete_coordinator** - Changed all references from "extraction" to "compilation":
   - Line 624: `current_stage="compilation"`
   - Line 637: `status="needs_compilation"`
   - Line 642: Log message now says "compilation stage"
   - Line 646: `next_stage="compilation"`
   - Line 664: Job tracking uses `stage="compilation"`

2. **deploy_job** - Added `sites.current_stage = "completed"` update alongside the status update (line 1075)

3. **cli.py** - Updated stuck site detection to reference `"needs_compilation"` instead of `"needs_extraction"`

4. **Test fix** - Updated `test_coordinator_resets_enqueued_flag` to expect "compilation" stage

5. **CLI command** - Added `clerk fix-extraction-stage` command to fix the 400 sites currently stuck at "extraction" stage

## Architecture

The pipeline has two separate flows:

**Core pipeline (fast path):**
```
fetch → OCR → compilation (extract_entities=False) → deploy → completed
```
- Uses cached entities if available, empty if not
- This is the default path for all sites

**Separate extraction flow (optional):**
```
extraction_job → compilation (extract_entities=True) → deploy → completed
```
- Can run independently for sites that need entity extraction
- Typically runs after a site has been successfully deployed once
- Currently disabled (Path 2 in ocr_complete_coordinator is commented out)

## Testing

- All 311 tests pass
- Updated 1 test to expect correct stage name
- Verified new CLI command works with `--help` and `--dry-run`

## Migration Required

After deployment, run the CLI command to fix the 400 stuck sites:

```bash
# Preview what will be fixed
clerk fix-extraction-stage --dry-run

# Apply the fix
clerk fix-extraction-stage
```

This will update all sites with `current_stage="extraction"` and `status="deployed"` to have `current_stage="completed"`.

## Files Changed

- `src/clerk/workers.py` - Fixed stage tracking in coordinator and deploy job
- `src/clerk/cli.py` - Updated status references and added migration command
- `tests/test_workers.py` - Updated test expectations
- `scripts/fix_extraction_stage.py` - Reference migration script (CLI command is the recommended approach)