### PR TITLE
Fix diagnostic logs to use structured JSON format

### DIFF
--- a/src/clerk/cli.py
+++ b/src/clerk/cli.py
@@ -1317,9 +1317,15 @@ def worker(worker_type, num_workers, burst):
                 # Safely convert args to string (handles MagicMock in tests)
                 args_str = str(job.args) if job.args else "none"
                 args_preview = args_str[:50] if len(args_str) > 50 else args_str
-                print(
-                    f"[PRE-FORK] job_id={job.id} func={job.func_name} args={args_preview}",
-                    file=sys.stderr,
+                # Use structured logging for Loki/Grafana visibility
+                logger.info(
+                    "worker_pre_fork",
+                    extra={
+                        "stage": "pre_fork",
+                        "job_id": job.id,
+                        "func_name": job.func_name,
+                        "args_preview": args_preview,
+                    },
                 )
                 sys.stderr.flush()
             except Exception:
@@ -1330,7 +1336,13 @@ def worker(worker_type, num_workers, burst):
 
             # Log AFTER fork completes (back in parent process)
             try:
-                print(f"[POST-FORK] job_id={job.id} completed", file=sys.stderr)
+                logger.info(
+                    "worker_post_fork",
+                    extra={
+                        "stage": "post_fork",
+                        "job_id": job.id,
+                    },
+                )
                 sys.stderr.flush()
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

Convert DiagnosticWorker PRE-FORK and POST-FORK logs from plain text to structured JSON format so they're visible in Loki/Grafana.

## Problem

The diagnostic logging added in PR #98 was using `print()` statements to stderr, which created unstructured text logs like:
```
[PRE-FORK] job_id=abc123 func=clerk.workers.ocr_page_job args=none
```

However, Loki/Grafana only parses JSON-structured log lines. These plain text logs existed in the `.error.log` files but were invisible in the centralized logging system, defeating their purpose of helping debug signal 11 crashes.

## Solution

Replace `print()` calls with `logger.info()` calls that create structured JSON logs:
```json
{
  "timestamp": "2026-01-22 21:29:20,465",
  "level": "INFO",
  "logger": "clerk.cli",
  "message": "worker_pre_fork",
  "stage": "pre_fork",
  "job_id": "abc123",
  "func_name": "clerk.workers.ocr_page_job",
  "args_preview": "none"
}
```

## Changes

- `DiagnosticWorker.perform_job()`: Replace print() with logger.info() for pre_fork stage
- `DiagnosticWorker.perform_job()`: Replace print() with logger.info() for post_fork stage
- Add structured fields: `stage`, `job_id`, `func_name`, `args_preview`

## Test Plan

- [x] All existing tests pass
- [ ] Deploy to production
- [ ] Verify "worker_pre_fork" and "worker_post_fork" messages appear in Grafana
- [ ] Use these logs to identify where signal 11 crashes occur in the RQ worker lifecycle