### PR TITLE
Fix WeasyPrint dependencies on macOS

### DIFF
--- a/docs/setup/prerequisites.md
+++ b/docs/setup/prerequisites.md
@@ -121,6 +121,28 @@ sudo apt install poppler-utils
 pdftoppm -v
 ```
 
+### WeasyPrint Dependencies
+
+HTML to PDF conversion (used by some fetchers).
+
+**macOS:**
+```bash
+brew install pango cairo glib gobject-introspection
+```
+
+**Linux (Ubuntu/Debian):**
+```bash
+sudo apt install libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev
+```
+
+**Note:** On macOS, the `clerk install-workers` command automatically configures the library path for these dependencies. If running clerk manually, you may need to set:
+
+```bash
+export DYLD_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_LIBRARY_PATH"  # Apple Silicon
+# or
+export DYLD_LIBRARY_PATH="/usr/local/lib:$DYLD_LIBRARY_PATH"     # Intel Mac
+```
+
 ### spaCy Language Model
 
 Entity extraction (optional).

--- a/scripts/install-workers.sh
+++ b/scripts/install-workers.sh
@@ -73,9 +73,11 @@ ARCH=$(uname -m)
 if [ "$ARCH" = "arm64" ]; then
     # Apple Silicon: Homebrew is in /opt/homebrew
     PATH_VAR="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    DYLD_LIBRARY_PATH_VAR="/opt/homebrew/lib"
 else
     # Intel: Homebrew is in /usr/local
     PATH_VAR="/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
+    DYLD_LIBRARY_PATH_VAR="/usr/local/lib"
 fi
 
 # Get clerk executable path
@@ -122,6 +124,7 @@ echo "  SENTRY_DSN: ${SENTRY_DSN:-not set}"
 echo "  SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT}"
 echo "  SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE}"
 echo "  PATH: ${PATH_VAR}"
+echo "  DYLD_LIBRARY_PATH: ${DYLD_LIBRARY_PATH_VAR}"
 echo ""
 echo "Worker counts:"
 echo "  FETCH_WORKERS: ${FETCH_WORKERS}"
@@ -153,6 +156,7 @@ create_worker() {
         sed "s|{{STORAGE_DIR}}|${STORAGE_DIR}|g" | \
         sed "s|{{DEFAULT_OCR_BACKEND}}|${DEFAULT_OCR_BACKEND}|g" | \
         sed "s|{{PATH}}|${PATH_VAR}|g" | \
+        sed "s|{{DYLD_LIBRARY_PATH}}|${DYLD_LIBRARY_PATH_VAR}|g" | \
         sed "s|{{LOKI_URL}}|${LOKI_URL}|g" | \
         sed "s|{{SENTRY_DSN}}|${SENTRY_DSN}|g" | \
         sed "s|{{SENTRY_ENVIRONMENT}}|${SENTRY_ENVIRONMENT}|g" | \

--- a/scripts/launchd-worker-template.plist
+++ b/scripts/launchd-worker-template.plist
@@ -34,6 +34,8 @@
         <string>{{SENTRY_TRACES_SAMPLE_RATE}}</string>
         <key>PYTHONUNBUFFERED</key>
         <string>1</string>
+        <key>DYLD_LIBRARY_PATH</key>
+        <string>{{DYLD_LIBRARY_PATH}}</string>
     </dict>
     <key>StandardOutPath</key>
     <string>{{LOG_DIR}}/clerk-worker-{{WORKER_TYPE}}-{{WORKER_NUM}}.log</string>


### PR DESCRIPTION
## Summary
- Fix WeasyPrint import errors on fresh macOS installations
- Automatically configure DYLD_LIBRARY_PATH for WeasyPrint system libraries (Pango, GObject, Cairo)
- Document WeasyPrint dependencies in prerequisites

## Problem
On a new macOS machine, running `clerk install-workers` fails with:
```
OSError: cannot load library 'gobject-2.0-0': dlopen(gobject-2.0-0, 0x0002): tried: 'gobject-2.0-0' (no such file)...
```

This occurs because WeasyPrint requires system libraries (Pango, Cairo, GObject) installed via Homebrew, but Python can't find them without `DYLD_LIBRARY_PATH` being set.

## Solution
### 1. Auto-configure library path in LaunchAgents
Modified `scripts/install-workers.sh` to:
- Auto-detect architecture (Apple Silicon vs Intel)
- Set `DYLD_LIBRARY_PATH_VAR` to appropriate Homebrew lib directory:
  - `/opt/homebrew/lib` for Apple Silicon (arm64)
  - `/usr/local/lib` for Intel (x86_64)
- Substitute `{{DYLD_LIBRARY_PATH}}` in LaunchAgent plist templates

### 2. Update LaunchAgent template
Added `DYLD_LIBRARY_PATH` to `scripts/launchd-worker-template.plist` environment variables section.

### 3. Document dependencies
Updated `docs/setup/prerequisites.md` to:
- Add WeasyPrint dependencies section
- Document required Homebrew packages: `pango cairo glib gobject-introspection`
- Provide manual workaround for running clerk outside of LaunchAgents

## Testing
- ✅ All existing tests pass (`pytest tests/test_cli.py -k worker`)
- ✅ Plist template validates (`plutil -lint`)
- ✅ Verified template contains `DYLD_LIBRARY_PATH` placeholder
- ✅ Verified install script defines and substitutes the variable
- ✅ Tested on new production macOS machine - `clerk install-workers` now succeeds

## Checklist
- [x] Code changes
- [x] Tests pass
- [x] Documentation updated
- [x] Tested on target platform (macOS)