### PR TITLE
Replace clerk new command with clerk etl new

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install "civicband-clerk[pdf,extraction] @ git+https://github.com/civicband/
 
 ```bash
 # Create a new site
-clerk new
+clerk etl new
 
 # Update a site (enqueues fetch → OCR → compilation → deploy)
 clerk update --subdomain example.civic.band

--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -7,7 +7,7 @@ Common workflows and CLI commands for working with clerk.
 ### Create New Site
 
 ```bash
-clerk new
+clerk etl new
 ```
 
 Interactive prompt to create a new site.
@@ -43,7 +43,7 @@ This command:
 ### Manual vs Auto Priority
 
 **High priority** (processed first):
-- New sites: `clerk new <subdomain>`
+- New sites: `clerk etl new <subdomain>`
 - Manual updates: `clerk update -s <subdomain>`
 
 **Normal priority** (processed after high queue empty):
@@ -151,7 +151,7 @@ clerk --plugins-dir=/path/to/plugins update --subdomain example.civic.band
 
 ```bash
 # 1. Create site
-clerk new
+clerk etl new
 
 # 2. Fetch all data
 clerk update --subdomain example.civic.band --all-years

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,7 +12,7 @@ This tutorial walks through creating your first site and running the data pipeli
 Create a new civic site:
 
 ```bash
-clerk new
+clerk etl new
 ```
 
 You'll be prompted for:

--- a/docs/plans/2026-01-04-readthedocs-setup-implementation.md
+++ b/docs/plans/2026-01-04-readthedocs-setup-implementation.md
@@ -328,7 +328,7 @@ This tutorial walks through creating your first site and running the data pipeli
 Create a new civic site:
 
 ```bash
-clerk new
+clerk etl new
 ```
 
 You'll be prompted for:
@@ -429,7 +429,7 @@ Shows all sites in civic.db with their status.
 ### Create New Site
 
 ```bash
-clerk new
+clerk etl new
 ```
 
 Interactive prompt to create a new site.
@@ -550,7 +550,7 @@ clerk --plugins-dir=/path/to/plugins update --subdomain example.civic.band
 
 ```bash
 # 1. Create site
-clerk new
+clerk etl new
 
 # 2. Fetch all data
 clerk update --subdomain example.civic.band --all-years

--- a/docs/plans/2026-01-14-auto-enqueue-scheduler-completion.md
+++ b/docs/plans/2026-01-14-auto-enqueue-scheduler-completion.md
@@ -8,7 +8,7 @@
 ✅ `get_oldest_site()` helper function with tests
 ✅ `clerk update --next-site` auto-scheduler mode (normal priority)
 ✅ `clerk update -s <subdomain>` manual mode (high priority)
-✅ `clerk new` auto-enqueues with high priority
+✅ `clerk etl new` auto-enqueues with high priority
 ✅ `clerk enqueue` verified to use normal priority default
 ✅ Integration tests for full workflow
 ✅ Documentation updated (basic usage, deployment, README)
@@ -17,7 +17,7 @@
 
 - Unit tests: `get_oldest_site()` function (4 tests)
 - Unit tests: `clerk update --next-site` (4 tests)
-- Unit tests: `clerk new` enqueue (1 test)
+- Unit tests: `clerk etl new` enqueue (1 test)
 - Unit tests: `clerk enqueue` priority (2 tests)
 - Integration test: Full workflow (1 test)
 

--- a/docs/plans/2026-01-14-auto-enqueue-scheduler-design.md
+++ b/docs/plans/2026-01-14-auto-enqueue-scheduler-design.md
@@ -30,7 +30,7 @@ The new RQ worker architecture enables parallel processing but requires a schedu
 
 ### Command Behavior
 
-**1. `clerk new <subdomain>` - Create new site**
+**1. `clerk etl new <subdomain>` - Create new site**
 - Creates site record in database (existing behavior)
 - Enqueues site with **high priority**
 - New sites process immediately
@@ -125,7 +125,7 @@ def update(subdomain, next_site, all_years, ...):
     raise click.UsageError("Must specify --subdomain or --next-site")
 ```
 
-**`clerk new` command**:
+**`clerk etl new` command**:
 ```python
 @cli.command()
 @click.argument('subdomain')
@@ -203,7 +203,7 @@ if not subdomain:
 
 **New site**:
 ```bash
-14:00 - User runs: clerk new brand-new-city
+14:00 - User runs: clerk etl new brand-new-city
         → Site created in database (last_updated = NULL)
         → Enqueued with high priority
         → Processes immediately
@@ -248,7 +248,7 @@ All of these can be added later without changing the core design.
 
 - [ ] Add `get_oldest_site()` helper function
 - [ ] Update `clerk update` command to handle `--next-site` flag
-- [ ] Update `clerk new` command to auto-enqueue with high priority
+- [ ] Update `clerk etl new` command to auto-enqueue with high priority
 - [ ] Update `clerk update -s` to enqueue with high priority instead of processing synchronously
 - [ ] Add logging for auto-enqueue operations
 - [ ] Update documentation with new command behavior

--- a/docs/plans/2026-01-14-auto-enqueue-scheduler.md
+++ b/docs/plans/2026-01-14-auto-enqueue-scheduler.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add automatic site scheduling via `clerk update --next` that enqueues the least-recently-updated site every minute via cron, while making manual commands (`new`, `update -s`) use high priority.
 
-**Architecture:** Modify `clerk update` command to support both manual high-priority enqueues and auto-scheduler normal-priority enqueues. Add `get_oldest_site()` helper to query for least-recently-updated site. Update `clerk new` to auto-enqueue after creation.
+**Architecture:** Modify `clerk update` command to support both manual high-priority enqueues and auto-scheduler normal-priority enqueues. Add `get_oldest_site()` helper to query for least-recently-updated site. Update `clerk etl new` to auto-enqueue after creation.
 
 **Tech Stack:** SQLAlchemy, Click, pytest, existing RQ queue infrastructure
 
@@ -340,7 +340,7 @@ git commit -m "feat: update clerk update command for auto-scheduling
 
 ---
 
-## Task 3: Update `clerk new` to Auto-Enqueue with High Priority
+## Task 3: Update `clerk etl new` to Auto-Enqueue with High Priority
 
 **Files:**
 - Modify: `src/clerk/cli.py` (update `new` command)
@@ -356,7 +356,7 @@ class TestNewCommand:
     """Tests for the new command."""
 
     def test_new_creates_site_and_enqueues_with_high_priority(self, cli_runner, mocker):
-        """clerk new should create site and enqueue with high priority."""
+        """clerk etl new should create site and enqueue with high priority."""
         # Mock database operations
         mock_conn = mocker.MagicMock()
         mock_conn.__enter__ = mocker.Mock(return_value=mock_conn)
@@ -391,7 +391,7 @@ Run: `uv run pytest tests/test_cli.py::TestNewCommand::test_new_creates_site_and
 
 Expected: FAIL - new command doesn't enqueue yet
 
-**Step 3: Update `clerk new` command implementation**
+**Step 3: Update `clerk etl new` command implementation**
 
 Find the `new` command in `src/clerk/cli.py` and update it to add enqueueing after site creation. Look for the function definition and add the enqueue call:
 
@@ -653,7 +653,7 @@ This command:
 ### Manual vs Auto Priority
 
 **High priority** (processed first):
-- New sites: `clerk new <subdomain>`
+- New sites: `clerk etl new <subdomain>`
 - Manual updates: `clerk update -s <subdomain>`
 
 **Normal priority** (processed after high queue empty):
@@ -713,7 +713,7 @@ Manual operations use high priority and jump to the front of the queue:
 
 ```bash
 # New site - high priority
-clerk new new-city.civic.band
+clerk etl new new-city.civic.band
 
 # Manual update - high priority
 clerk update -s important-city.civic.band
@@ -811,7 +811,7 @@ Create a completion summary in `docs/plans/2026-01-14-auto-enqueue-scheduler-com
 ✅ `get_oldest_site()` helper function with tests
 ✅ `clerk update --next` auto-scheduler mode (normal priority)
 ✅ `clerk update -s <subdomain>` manual mode (high priority)
-✅ `clerk new` auto-enqueues with high priority
+✅ `clerk etl new` auto-enqueues with high priority
 ✅ `clerk enqueue` verified to use normal priority default
 ✅ Integration tests for full workflow
 ✅ Documentation updated (basic usage, deployment, README)
@@ -821,7 +821,7 @@ Create a completion summary in `docs/plans/2026-01-14-auto-enqueue-scheduler-com
 - Unit tests: `get_oldest_site()` function (4 tests)
 - Unit tests: `clerk update --next` (2 tests)
 - Unit tests: `clerk update -s` (1 test)
-- Unit tests: `clerk new` enqueue (1 test)
+- Unit tests: `clerk etl new` enqueue (1 test)
 - Unit tests: `clerk enqueue` priority (2 tests)
 - Integration test: Full workflow (1 test)
 

--- a/docs/plans/2026-01-16-documentation-overhaul-implementation.md
+++ b/docs/plans/2026-01-16-documentation-overhaul-implementation.md
@@ -895,7 +895,7 @@ Active Workers:
 ### 1. Create a test site
 
 ```bash
-clerk new test-city.civic.band
+clerk etl new test-city.civic.band
 ```
 
 Follow prompts to configure site.
@@ -1454,7 +1454,7 @@ Expected:
 ### 1. Create Test Site
 
 ```bash
-clerk new test-verification.civic.band
+clerk etl new test-verification.civic.band
 ```
 
 When prompted:
@@ -2186,7 +2186,7 @@ pip install "clerk[pdf,extraction] @ git+https://github.com/civicband/clerk.git"
 
 ```bash
 # Create a new site
-clerk new
+clerk etl new
 
 # Update a site (enqueues fetch → OCR → compilation → deploy)
 clerk update --subdomain example.civic.band

--- a/docs/plans/POSTGRES_MIGRATION.md
+++ b/docs/plans/POSTGRES_MIGRATION.md
@@ -28,11 +28,11 @@ The system automatically detects which database to use based on the `DATABASE_UR
 Example:
 ```bash
 # Development mode (SQLite)
-clerk new my-city --name "My City"
+clerk etl new my-city --name "My City"
 
 # Production mode (PostgreSQL)
 export DATABASE_URL="postgresql://user:pass@host:5432/civicband"
-clerk new my-city --name "My City"
+clerk etl new my-city --name "My City"
 ```
 
 ## Installation

--- a/docs/setup/single-machine.md
+++ b/docs/setup/single-machine.md
@@ -159,7 +159,7 @@ Active Workers:
 ### 1. Create a test site
 
 ```bash
-clerk new test-city.civic.band
+clerk etl new test-city.civic.band
 ```
 
 Follow prompts to configure site.

--- a/docs/setup/verification.md
+++ b/docs/setup/verification.md
@@ -46,7 +46,7 @@ Expected:
 ### 1. Create Test Site
 
 ```bash
-clerk new test-verification.civic.band
+clerk etl new test-verification.civic.band
 ```
 
 When prompted:


### PR DESCRIPTION
<!--- Describe your changes in detail -->
 Fix incorrect CLI command in documentation from `clerk new` to `clerk etl new`.   Running `clerk new` would previously produce `Error: No such command 'new'`.

<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist

<!--- If existing, please state which site -->
New site, or existing?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the CivicBand Code of Conduct
- [x] I will abide by the CivicBand Contributor Guide
- [ ] This PR was generated or assisted using an AI tool
<!-- AI assistance is allowed, but must be marked -->
<!-- update or delete the next line to reflect your usage -->
