### PR TITLE
Update etl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install "civicband-clerk[pdf,extraction] @ git+https://github.com/civicband/
 
 ```bash
 # Create a new site
-clerk new
+clerk etl new
 
 # Update a site (enqueues fetch → OCR → compilation → deploy)
 clerk update --subdomain example.civic.band

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pip install "civicband-clerk[pdf,extraction] @ git+https://github.com/civicband/
 clerk etl new
 
 # Update a site (enqueues fetch → OCR → compilation → deploy)
-clerk update --subdomain example.civic.band
+clerk etl update --subdomain example.civic.band
 
 # Check status
 clerk status

--- a/deployment/launchd/update-wrapper.sh.template
+++ b/deployment/launchd/update-wrapper.sh.template
@@ -59,10 +59,10 @@ cd "$WORK_DIR" || {
 }
 
 # Run the update with timeout
-log "Starting clerk update"
+log "Starting clerk etl update"
 START_TIME=$(date +%s)
 
-if {{GTIMEOUT_PATH}} "$TIMEOUT" {{UV_PATH}} run clerk update -n; then
+if {{GTIMEOUT_PATH}} "$TIMEOUT" {{UV_PATH}} run clerk etl update -n; then
     EXIT_CODE=$?
     END_TIME=$(date +%s)
     DURATION=$((END_TIME - START_TIME))

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,7 @@ Guide for deploying clerk in production with automated updates.
 
 Clerk provides built-in support for automated updates using macOS's launchd system. The `clerk install-launchd` command sets up scheduled jobs that:
 
-- Run `clerk update -n` every 60 seconds
+- Run `clerk etl update -n` every 60 seconds
 - Monitor for failures and send alerts
 - Prevent overlapping runs with lock files
 - Log all activity for debugging
@@ -191,7 +191,7 @@ If updates stop running and you see "Lock file stuck" messages:
 
 ```bash
 # Check if process is actually running
-ps aux | grep "clerk update"
+ps aux | grep "clerk etl update"
 
 # If no process, remove stuck lock
 rm /tmp/civicband-update-$(whoami).lock
@@ -207,7 +207,7 @@ If multiple processes pile up:
 
 ```bash
 # Kill all hung clerk processes
-pkill -f "clerk update -n"
+pkill -f "clerk etl update -n"
 
 # Check for issues in logs
 tail -100 logs/update.error.log
@@ -271,12 +271,12 @@ If you're migrating from cron:
 1. **Disable old cron job:**
    ```bash
    crontab -e
-   # Comment out or remove the clerk update line
+   # Comment out or remove the clerk etl update line
    ```
 
 2. **Kill any hung cron processes:**
    ```bash
-   pkill -f "clerk update"
+   pkill -f "clerk etl update"
    ```
 
 3. **Install launchd:**
@@ -303,7 +303,7 @@ To automatically update all sites once per day, set up a cron job:
 crontab -e
 
 # Add this line to run every minute:
-* * * * * cd /path/to/clerk && /path/to/uv run clerk update --next-site >> /var/log/clerk/auto-enqueue.log 2>&1
+* * * * * cd /path/to/clerk && /path/to/uv run clerk etl update --next-site >> /var/log/clerk/auto-enqueue.log 2>&1
 ```
 
 **Monitoring:**

--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -16,13 +16,13 @@ Interactive prompt to create a new site.
 
 ```bash
 # Specific site
-clerk update --subdomain example.civic.band
+clerk etl update --subdomain example.civic.band
 
 # Next site needing update
-clerk update --next-site
+clerk etl update --next-site
 
 # All historical data
-clerk update --subdomain example.civic.band --all-years
+clerk etl update --subdomain example.civic.band --all-years
 ```
 
 ### Auto-Scheduling Sites
@@ -31,7 +31,7 @@ The auto-scheduler ensures all sites update approximately once per day:
 
 ```bash
 # Run via cron every minute to auto-enqueue oldest site
-clerk update --next-site
+clerk etl update --next-site
 ```
 
 This command:
@@ -44,10 +44,10 @@ This command:
 
 **High priority** (processed first):
 - New sites: `clerk etl new <subdomain>`
-- Manual updates: `clerk update -s <subdomain>`
+- Manual updates: `clerk etl update -s <subdomain>`
 
 **Normal priority** (processed after high queue empty):
-- Auto-scheduler: `clerk update --next-site`
+- Auto-scheduler: `clerk etl update --next-site`
 - Bulk operations: `clerk enqueue site1 site2 site3`
 
 ## Database Operations
@@ -90,13 +90,13 @@ OCR is handled automatically as part of the `update` command. You can choose the
 ### Update with Tesseract (default)
 
 ```bash
-clerk update --subdomain example.civic.band
+clerk etl update --subdomain example.civic.band
 ```
 
 ### Update with Vision Framework (macOS)
 
 ```bash
-clerk update --subdomain example.civic.band --ocr-backend vision
+clerk etl update --subdomain example.civic.band --ocr-backend vision
 ```
 
 Vision Framework is 3-5x faster on Apple Silicon and automatically falls back to Tesseract if it fails.
@@ -141,7 +141,7 @@ clerk --plugins-dir=/path/to/plugins update --subdomain example.civic.band
 
 ```bash
 # Every 6 hours: update next site
-0 */6 * * * clerk update --next-site
+0 */6 * * * clerk etl update --next-site
 
 # Every 30 minutes: extract entities
 */30 * * * * clerk extract-entities --next-site
@@ -154,7 +154,7 @@ clerk --plugins-dir=/path/to/plugins update --subdomain example.civic.band
 clerk etl new
 
 # 2. Fetch all data
-clerk update --subdomain example.civic.band --all-years
+clerk etl update --subdomain example.civic.band --all-years
 
 # 3. Build database (fast)
 clerk build-db-from-text --subdomain example.civic.band

--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -7,7 +7,7 @@ Common workflows and CLI commands for working with clerk.
 ### Create New Site
 
 ```bash
-clerk new
+clerk etl new
 ```
 
 Interactive prompt to create a new site.
@@ -43,7 +43,7 @@ This command:
 ### Manual vs Auto Priority
 
 **High priority** (processed first):
-- New sites: `clerk new <subdomain>`
+- New sites: `clerk etl new <subdomain>`
 - Manual updates: `clerk update -s <subdomain>`
 
 **Normal priority** (processed after high queue empty):
@@ -151,7 +151,7 @@ clerk --plugins-dir=/path/to/plugins update --subdomain example.civic.band
 
 ```bash
 # 1. Create site
-clerk new
+clerk etl new
 
 # 2. Fetch all data
 clerk update --subdomain example.civic.band --all-years

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,7 +12,7 @@ This tutorial walks through creating your first site and running the data pipeli
 Create a new civic site:
 
 ```bash
-clerk new
+clerk etl new
 ```
 
 You'll be prompted for:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -33,7 +33,7 @@ This creates a site entry in the civic.db database and a directory structure at 
 Update the site to fetch data:
 
 ```bash
-clerk update --subdomain berkeleyca.civic.band
+clerk etl update --subdomain berkeleyca.civic.band
 ```
 
 This runs the complete pipeline:
@@ -46,10 +46,10 @@ This runs the complete pipeline:
 
 ```bash
 # Fetch all historical data
-clerk update --subdomain berkeleyca.civic.band --all-years
+clerk etl update --subdomain berkeleyca.civic.band --all-years
 
 # Update next site that needs updating (for cron jobs)
-clerk update --next-site
+clerk etl update --next-site
 ```
 
 ## Step 3: Build Database

--- a/docs/plans/2025-12-03-plugin-directory-discovery-design.md
+++ b/docs/plans/2025-12-03-plugin-directory-discovery-design.md
@@ -25,7 +25,7 @@ if __name__ == "__main__":
 Users run `clerk` directly, and plugins are discovered automatically:
 
 ```bash
-clerk update -s foo.civic.band
+clerk etl update -s foo.civic.band
 ```
 
 ## Design
@@ -45,7 +45,7 @@ clerk update -s foo.civic.band
 
 ```bash
 # Uses ./plugins/ by default
-clerk update -s foo.civic.band
+clerk etl update -s foo.civic.band
 
 # Override plugins directory
 clerk --plugins-dir ./my-plugins update -s foo.civic.band

--- a/docs/plans/2026-01-04-readthedocs-setup-implementation.md
+++ b/docs/plans/2026-01-04-readthedocs-setup-implementation.md
@@ -328,7 +328,7 @@ This tutorial walks through creating your first site and running the data pipeli
 Create a new civic site:
 
 ```bash
-clerk new
+clerk etl new
 ```
 
 You'll be prompted for:
@@ -429,7 +429,7 @@ Shows all sites in civic.db with their status.
 ### Create New Site
 
 ```bash
-clerk new
+clerk etl new
 ```
 
 Interactive prompt to create a new site.
@@ -550,7 +550,7 @@ clerk --plugins-dir=/path/to/plugins update --subdomain example.civic.band
 
 ```bash
 # 1. Create site
-clerk new
+clerk etl new
 
 # 2. Fetch all data
 clerk update --subdomain example.civic.band --all-years

--- a/docs/plans/2026-01-04-readthedocs-setup-implementation.md
+++ b/docs/plans/2026-01-04-readthedocs-setup-implementation.md
@@ -349,7 +349,7 @@ This creates a site entry in the civic.db database and a directory structure at 
 Update the site to fetch data:
 
 ```bash
-clerk update --subdomain berkeleyca.civic.band
+clerk etl update --subdomain berkeleyca.civic.band
 ```
 
 This runs the complete pipeline:
@@ -362,10 +362,10 @@ This runs the complete pipeline:
 
 ```bash
 # Fetch all historical data
-clerk update --subdomain berkeleyca.civic.band --all-years
+clerk etl update --subdomain berkeleyca.civic.band --all-years
 
 # Update next site that needs updating (for cron jobs)
-clerk update --next-site
+clerk etl update --next-site
 ```
 
 ## Step 3: Build Database
@@ -438,13 +438,13 @@ Interactive prompt to create a new site.
 
 ```bash
 # Specific site
-clerk update --subdomain example.civic.band
+clerk etl update --subdomain example.civic.band
 
 # Next site needing update
-clerk update --next-site
+clerk etl update --next-site
 
 # All historical data
-clerk update --subdomain example.civic.band --all-years
+clerk etl update --subdomain example.civic.band --all-years
 ```
 
 ## Database Operations
@@ -540,7 +540,7 @@ clerk --plugins-dir=/path/to/plugins update --subdomain example.civic.band
 
 ```bash
 # Every 6 hours: update next site
-0 */6 * * * clerk update --next-site
+0 */6 * * * clerk etl update --next-site
 
 # Every 30 minutes: extract entities
 */30 * * * * clerk extract-entities --next-site
@@ -553,7 +553,7 @@ clerk --plugins-dir=/path/to/plugins update --subdomain example.civic.band
 clerk etl new
 
 # 2. Fetch all data
-clerk update --subdomain example.civic.band --all-years
+clerk etl update --subdomain example.civic.band --all-years
 
 # 3. Build database (fast)
 clerk build-db-from-text --subdomain example.civic.band

--- a/docs/plans/2026-01-04-vision-framework-ocr-design.md
+++ b/docs/plans/2026-01-04-vision-framework-ocr-design.md
@@ -352,7 +352,7 @@ def _ocr_with_vision(self, image_path: Path) -> str:
    - Vision tests skipped gracefully on other platforms
 
 **Manual Testing Checklist:**
-- [ ] Run `clerk update --ocr-backend=vision` on M2 Mac
+- [ ] Run `clerk etl update --ocr-backend=vision` on M2 Mac
 - [ ] Compare output quality vs Tesseract
 - [ ] Verify PNGs uploaded correctly
 - [ ] Test fallback by triggering Vision error
@@ -385,7 +385,7 @@ For existing clerk deployments:
 
 2. **Phase 1 - Testing**
    - Install Vision dependencies: `pip install pyobjc-framework-Vision pyobjc-framework-Quartz`
-   - Test on specific sites: `clerk update example.com --ocr-backend=vision`
+   - Test on specific sites: `clerk etl update example.com --ocr-backend=vision`
    - Compare quality and performance
 
 3. **Phase 2 - Gradual Rollout**
@@ -426,14 +426,14 @@ Clerk supports two OCR backends:
 - Cross-platform (Linux, macOS, Windows)
 - Supports 100+ languages
 - Requires tesseract binary installed
-- Usage: `clerk update` (default) or `clerk update --ocr-backend=tesseract`
+- Usage: `clerk etl update` (default) or `clerk etl update --ocr-backend=tesseract`
 
 ### Vision Framework (macOS only)
 - Requires M1+ Mac (Neural Engine)
 - 3-5x faster than Tesseract on Apple Silicon
 - Automatic language detection
 - Requires: `pip install pyobjc-framework-Vision pyobjc-framework-Quartz`
-- Usage: `clerk update --ocr-backend=vision`
+- Usage: `clerk etl update --ocr-backend=vision`
 
 ### Fallback Behavior
 If Vision is selected but fails (missing dependencies, errors), clerk automatically falls back to Tesseract and logs a warning.
@@ -467,7 +467,7 @@ If Vision is selected but fails (missing dependencies, errors), clerk automatica
 
 ## Success Criteria
 
-- [ ] `clerk update --ocr-backend=vision` works on M2 Mac
+- [ ] `clerk etl update --ocr-backend=vision` works on M2 Mac
 - [ ] Text output quality comparable to Tesseract
 - [ ] 3-5x performance improvement measured
 - [ ] Automatic fallback works when Vision fails

--- a/docs/plans/2026-01-04-vision-framework-ocr-implementation.md
+++ b/docs/plans/2026-01-04-vision-framework-ocr-implementation.md
@@ -819,7 +819,7 @@ Clerk supports two OCR backends:
 - **Cross-platform:** Linux, macOS, Windows
 - **Languages:** 100+ languages supported
 - **Setup:** Requires tesseract binary installed
-- **Usage:** `clerk update example.com` (default) or `clerk update example.com --ocr-backend=tesseract`
+- **Usage:** `clerk etl update example.com` (default) or `clerk etl update example.com --ocr-backend=tesseract`
 
 ### Vision Framework (macOS only)
 
@@ -827,7 +827,7 @@ Clerk supports two OCR backends:
 - **Performance:** 3-5x faster than Tesseract on Apple Silicon
 - **Languages:** Automatic language detection
 - **Setup:** `pip install pyobjc-framework-Vision pyobjc-framework-Quartz`
-- **Usage:** `clerk update example.com --ocr-backend=vision`
+- **Usage:** `clerk etl update example.com --ocr-backend=vision`
 
 ### Automatic Fallback
 
@@ -835,7 +835,7 @@ If Vision Framework is selected but fails (missing dependencies, errors), clerk 
 
 ```bash
 # Try Vision, fall back to Tesseract if needed
-clerk update example.com --ocr-backend=vision
+clerk etl update example.com --ocr-backend=vision
 ```
 ```
 
@@ -855,7 +855,7 @@ git commit -m "Document system dependencies and OCR backend options"
 
 **Step 1: Test Tesseract backend (default)**
 
-Run: `clerk update test.example.com`
+Run: `clerk etl update test.example.com`
 
 Expected:
 - Processes with Tesseract backend
@@ -864,7 +864,7 @@ Expected:
 
 **Step 2: Test Vision backend on macOS**
 
-Run: `clerk update test.example.com --ocr-backend=vision`
+Run: `clerk etl update test.example.com --ocr-backend=vision`
 
 Expected:
 - Processes with Vision backend
@@ -876,7 +876,7 @@ Expected:
 
 Temporarily break Vision (e.g., uninstall pyobjc) and run:
 
-Run: `clerk update test.example.com --ocr-backend=vision`
+Run: `clerk etl update test.example.com --ocr-backend=vision`
 
 Expected:
 - Logs show Vision failure
@@ -889,10 +889,10 @@ Expected:
 Run same document with both backends and compare:
 
 ```bash
-clerk update test.example.com --ocr-backend=tesseract
+clerk etl update test.example.com --ocr-backend=tesseract
 mv ../sites/test.example.com/txt ../sites/test.example.com/txt-tesseract
 
-clerk update test.example.com --ocr-backend=vision
+clerk etl update test.example.com --ocr-backend=vision
 mv ../sites/test.example.com/txt ../sites/test.example.com/txt-vision
 
 diff -r ../sites/test.example.com/txt-tesseract ../sites/test.example.com/txt-vision
@@ -981,10 +981,10 @@ If you want to measure performance improvement:
 
 ```bash
 # Benchmark Tesseract
-time clerk update test.example.com --ocr-backend=tesseract
+time clerk etl update test.example.com --ocr-backend=tesseract
 
 # Benchmark Vision
-time clerk update test.example.com --ocr-backend=vision
+time clerk etl update test.example.com --ocr-backend=vision
 
 # Compare results
 ```

--- a/docs/plans/2026-01-06-task-queue-design.md
+++ b/docs/plans/2026-01-06-task-queue-design.md
@@ -22,7 +22,7 @@ This design introduces a distributed task queue system to replace the current si
 
 The existing launchd-based system has significant bottlenecks:
 
-1. **Serialization**: Lock file allows only one `clerk update -n` process at a time
+1. **Serialization**: Lock file allows only one `clerk etl update -n` process at a time
 2. **Single-site processing**: Each invocation processes one site sequentially through all stages
 3. **Resource underutilization**: On an 8-core machine, only ~1-2 cores are used during fetch/deploy
 4. **No parallelism**: OCR processing happens sequentially even though pages are independent
@@ -705,7 +705,7 @@ DEFAULT_OCR_BACKEND=tesseract
 ### For Existing Users
 
 **Old system** (launchd + lock file):
-- Single `clerk update -n` every 60 seconds
+- Single `clerk etl update -n` every 60 seconds
 - Lock file prevents concurrent execution
 - Processes 1 site at a time
 - ~24 sites per day

--- a/docs/plans/2026-01-14-auto-enqueue-scheduler-completion.md
+++ b/docs/plans/2026-01-14-auto-enqueue-scheduler-completion.md
@@ -8,7 +8,7 @@
 ✅ `get_oldest_site()` helper function with tests
 ✅ `clerk update --next-site` auto-scheduler mode (normal priority)
 ✅ `clerk update -s <subdomain>` manual mode (high priority)
-✅ `clerk new` auto-enqueues with high priority
+✅ `clerk etl new` auto-enqueues with high priority
 ✅ `clerk enqueue` verified to use normal priority default
 ✅ Integration tests for full workflow
 ✅ Documentation updated (basic usage, deployment, README)
@@ -17,7 +17,7 @@
 
 - Unit tests: `get_oldest_site()` function (4 tests)
 - Unit tests: `clerk update --next-site` (4 tests)
-- Unit tests: `clerk new` enqueue (1 test)
+- Unit tests: `clerk etl new` enqueue (1 test)
 - Unit tests: `clerk enqueue` priority (2 tests)
 - Integration test: Full workflow (1 test)
 

--- a/docs/plans/2026-01-14-auto-enqueue-scheduler-completion.md
+++ b/docs/plans/2026-01-14-auto-enqueue-scheduler-completion.md
@@ -6,8 +6,8 @@
 ## What Was Implemented
 
 ✅ `get_oldest_site()` helper function with tests
-✅ `clerk update --next-site` auto-scheduler mode (normal priority)
-✅ `clerk update -s <subdomain>` manual mode (high priority)
+✅ `clerk etl update --next-site` auto-scheduler mode (normal priority)
+✅ `clerk etl update -s <subdomain>` manual mode (high priority)
 ✅ `clerk etl new` auto-enqueues with high priority
 ✅ `clerk enqueue` verified to use normal priority default
 ✅ Integration tests for full workflow
@@ -16,7 +16,7 @@
 ## Test Coverage
 
 - Unit tests: `get_oldest_site()` function (4 tests)
-- Unit tests: `clerk update --next-site` (4 tests)
+- Unit tests: `clerk etl update --next-site` (4 tests)
 - Unit tests: `clerk etl new` enqueue (1 test)
 - Unit tests: `clerk enqueue` priority (2 tests)
 - Integration test: Full workflow (1 test)
@@ -37,7 +37,7 @@
 
 1. `6fffc8e` - Add auto-enqueue scheduler design
 2. `1ffddc9` - feat: add get_oldest_site helper function
-3. `82a98f8` - feat: update clerk update command for auto-scheduling
+3. `82a98f8` - feat: update clerk etl update command for auto-scheduling
 4. `33c2396` - feat: auto-enqueue new sites with high priority
 5. `10ca489` - test: verify enqueue defaults to normal priority
 6. `c36a986` - test: add integration test for auto-enqueue workflow
@@ -60,7 +60,7 @@
 - [ ] PR created and submitted for review
 - [ ] PR approved and merged
 - [ ] Changes deployed to production
-- [ ] Cron job configured: `* * * * * cd /path && uv run clerk update --next-site`
+- [ ] Cron job configured: `* * * * * cd /path && uv run clerk etl update --next-site`
 - [ ] Verify first auto-enqueue works
 - [ ] Monitor logs for 24 hours
 - [ ] Confirm all sites updating on schedule

--- a/docs/plans/2026-01-14-auto-enqueue-scheduler-design.md
+++ b/docs/plans/2026-01-14-auto-enqueue-scheduler-design.md
@@ -30,7 +30,7 @@ The new RQ worker architecture enables parallel processing but requires a schedu
 
 ### Command Behavior
 
-**1. `clerk new <subdomain>` - Create new site**
+**1. `clerk etl new <subdomain>` - Create new site**
 - Creates site record in database (existing behavior)
 - Enqueues site with **high priority**
 - New sites process immediately
@@ -125,7 +125,7 @@ def update(subdomain, next_site, all_years, ...):
     raise click.UsageError("Must specify --subdomain or --next-site")
 ```
 
-**`clerk new` command**:
+**`clerk etl new` command**:
 ```python
 @cli.command()
 @click.argument('subdomain')
@@ -203,7 +203,7 @@ if not subdomain:
 
 **New site**:
 ```bash
-14:00 - User runs: clerk new brand-new-city
+14:00 - User runs: clerk etl new brand-new-city
         → Site created in database (last_updated = NULL)
         → Enqueued with high priority
         → Processes immediately
@@ -248,7 +248,7 @@ All of these can be added later without changing the core design.
 
 - [ ] Add `get_oldest_site()` helper function
 - [ ] Update `clerk update` command to handle `--next-site` flag
-- [ ] Update `clerk new` command to auto-enqueue with high priority
+- [ ] Update `clerk etl new` command to auto-enqueue with high priority
 - [ ] Update `clerk update -s` to enqueue with high priority instead of processing synchronously
 - [ ] Add logging for auto-enqueue operations
 - [ ] Update documentation with new command behavior

--- a/docs/plans/2026-01-14-auto-enqueue-scheduler-design.md
+++ b/docs/plans/2026-01-14-auto-enqueue-scheduler-design.md
@@ -17,7 +17,7 @@ This design adds automatic site scheduling to the RQ-based task queue system. A 
 
 ## Motivation
 
-The new RQ worker architecture enables parallel processing but requires a scheduling mechanism to automatically feed sites into the queue. Previously, `clerk update -n` was called via launchd every 15 minutes to process one site synchronously. Now we need to enqueue sites at a regular cadence for workers to process.
+The new RQ worker architecture enables parallel processing but requires a scheduling mechanism to automatically feed sites into the queue. Previously, `clerk etl update -n` was called via launchd every 15 minutes to process one site synchronously. Now we need to enqueue sites at a regular cadence for workers to process.
 
 **Requirements:**
 1. All sites update approximately once per day
@@ -35,12 +35,12 @@ The new RQ worker architecture enables parallel processing but requires a schedu
 - Enqueues site with **high priority**
 - New sites process immediately
 
-**2. `clerk update -s <subdomain>` - Manual update**
+**2. `clerk etl update -s <subdomain>` - Manual update**
 - Enqueues specific site with **high priority**
 - Replaces old synchronous processing with async enqueue
 - Jumps to front of queue
 
-**3. `clerk update --next` - Auto-scheduler**
+**3. `clerk etl update --next` - Auto-scheduler**
 - Finds site with oldest `last_updated` timestamp
 - Skips sites updated within last 23 hours
 - Enqueues with **normal priority**
@@ -97,7 +97,7 @@ def get_oldest_site(lookback_hours=23):
 
 ### Implementation Changes
 
-**`clerk update` command**:
+**`clerk etl update` command**:
 ```python
 @cli.command()
 @click.option('-s', '--subdomain', help='Specific site subdomain')
@@ -172,7 +172,7 @@ if not subdomain:
 **Cron Configuration**:
 ```bash
 # Add to crontab: crontab -e
-* * * * * cd /path/to/project && /path/to/uv run clerk update --next >> /var/log/clerk/auto-enqueue.log 2>&1
+* * * * * cd /path/to/project && /path/to/uv run clerk etl update --next >> /var/log/clerk/auto-enqueue.log 2>&1
 ```
 
 **Monitoring**:
@@ -194,7 +194,7 @@ if not subdomain:
 
 **Manual override**:
 ```bash
-10:30 - User runs: clerk update -s important-city
+10:30 - User runs: clerk etl update -s important-city
         → important-city added to high-priority queue
         → Workers process high-priority queue first
         → important-city completes, last_updated set to 10:35
@@ -247,9 +247,9 @@ All of these can be added later without changing the core design.
 ## Implementation Checklist
 
 - [ ] Add `get_oldest_site()` helper function
-- [ ] Update `clerk update` command to handle `--next-site` flag
+- [ ] Update `clerk etl update` command to handle `--next-site` flag
 - [ ] Update `clerk etl new` command to auto-enqueue with high priority
-- [ ] Update `clerk update -s` to enqueue with high priority instead of processing synchronously
+- [ ] Update `clerk etl update -s` to enqueue with high priority instead of processing synchronously
 - [ ] Add logging for auto-enqueue operations
 - [ ] Update documentation with new command behavior
 - [ ] Add cron setup instructions to deployment docs

--- a/docs/plans/2026-01-14-auto-enqueue-scheduler.md
+++ b/docs/plans/2026-01-14-auto-enqueue-scheduler.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add automatic site scheduling via `clerk update --next` that enqueues the least-recently-updated site every minute via cron, while making manual commands (`new`, `update -s`) use high priority.
 
-**Architecture:** Modify `clerk update` command to support both manual high-priority enqueues and auto-scheduler normal-priority enqueues. Add `get_oldest_site()` helper to query for least-recently-updated site. Update `clerk new` to auto-enqueue after creation.
+**Architecture:** Modify `clerk update` command to support both manual high-priority enqueues and auto-scheduler normal-priority enqueues. Add `get_oldest_site()` helper to query for least-recently-updated site. Update `clerk etl new` to auto-enqueue after creation.
 
 **Tech Stack:** SQLAlchemy, Click, pytest, existing RQ queue infrastructure
 
@@ -340,7 +340,7 @@ git commit -m "feat: update clerk update command for auto-scheduling
 
 ---
 
-## Task 3: Update `clerk new` to Auto-Enqueue with High Priority
+## Task 3: Update `clerk etl new` to Auto-Enqueue with High Priority
 
 **Files:**
 - Modify: `src/clerk/cli.py` (update `new` command)
@@ -356,7 +356,7 @@ class TestNewCommand:
     """Tests for the new command."""
 
     def test_new_creates_site_and_enqueues_with_high_priority(self, cli_runner, mocker):
-        """clerk new should create site and enqueue with high priority."""
+        """clerk etl new should create site and enqueue with high priority."""
         # Mock database operations
         mock_conn = mocker.MagicMock()
         mock_conn.__enter__ = mocker.Mock(return_value=mock_conn)
@@ -391,7 +391,7 @@ Run: `uv run pytest tests/test_cli.py::TestNewCommand::test_new_creates_site_and
 
 Expected: FAIL - new command doesn't enqueue yet
 
-**Step 3: Update `clerk new` command implementation**
+**Step 3: Update `clerk etl new` command implementation**
 
 Find the `new` command in `src/clerk/cli.py` and update it to add enqueueing after site creation. Look for the function definition and add the enqueue call:
 
@@ -653,7 +653,7 @@ This command:
 ### Manual vs Auto Priority
 
 **High priority** (processed first):
-- New sites: `clerk new <subdomain>`
+- New sites: `clerk etl new <subdomain>`
 - Manual updates: `clerk update -s <subdomain>`
 
 **Normal priority** (processed after high queue empty):
@@ -713,7 +713,7 @@ Manual operations use high priority and jump to the front of the queue:
 
 ```bash
 # New site - high priority
-clerk new new-city.civic.band
+clerk etl new new-city.civic.band
 
 # Manual update - high priority
 clerk update -s important-city.civic.band
@@ -811,7 +811,7 @@ Create a completion summary in `docs/plans/2026-01-14-auto-enqueue-scheduler-com
 ✅ `get_oldest_site()` helper function with tests
 ✅ `clerk update --next` auto-scheduler mode (normal priority)
 ✅ `clerk update -s <subdomain>` manual mode (high priority)
-✅ `clerk new` auto-enqueues with high priority
+✅ `clerk etl new` auto-enqueues with high priority
 ✅ `clerk enqueue` verified to use normal priority default
 ✅ Integration tests for full workflow
 ✅ Documentation updated (basic usage, deployment, README)
@@ -821,7 +821,7 @@ Create a completion summary in `docs/plans/2026-01-14-auto-enqueue-scheduler-com
 - Unit tests: `get_oldest_site()` function (4 tests)
 - Unit tests: `clerk update --next` (2 tests)
 - Unit tests: `clerk update -s` (1 test)
-- Unit tests: `clerk new` enqueue (1 test)
+- Unit tests: `clerk etl new` enqueue (1 test)
 - Unit tests: `clerk enqueue` priority (2 tests)
 - Integration test: Full workflow (1 test)
 

--- a/docs/plans/2026-01-14-auto-enqueue-scheduler.md
+++ b/docs/plans/2026-01-14-auto-enqueue-scheduler.md
@@ -2,9 +2,9 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Add automatic site scheduling via `clerk update --next` that enqueues the least-recently-updated site every minute via cron, while making manual commands (`new`, `update -s`) use high priority.
+**Goal:** Add automatic site scheduling via `clerk etl update --next` that enqueues the least-recently-updated site every minute via cron, while making manual commands (`new`, `update -s`) use high priority.
 
-**Architecture:** Modify `clerk update` command to support both manual high-priority enqueues and auto-scheduler normal-priority enqueues. Add `get_oldest_site()` helper to query for least-recently-updated site. Update `clerk etl new` to auto-enqueue after creation.
+**Architecture:** Modify `clerk etl update` command to support both manual high-priority enqueues and auto-scheduler normal-priority enqueues. Add `get_oldest_site()` helper to query for least-recently-updated site. Update `clerk etl new` to auto-enqueue after creation.
 
 **Tech Stack:** SQLAlchemy, Click, pytest, existing RQ queue infrastructure
 
@@ -162,7 +162,7 @@ lookback window. Returns None if all sites recently updated."
 
 ---
 
-## Task 2: Update `clerk update --next` to Use Auto-Scheduler
+## Task 2: Update `clerk etl update --next` to Use Auto-Scheduler
 
 **Files:**
 - Modify: `src/clerk/cli.py` (update `update` command function)
@@ -178,7 +178,7 @@ class TestAutoEnqueueScheduler:
     """Tests for auto-enqueue scheduler functionality."""
 
     def test_update_next_enqueues_oldest_site(self, cli_runner, mocker):
-        """clerk update --next should enqueue the oldest site with normal priority."""
+        """clerk etl update --next should enqueue the oldest site with normal priority."""
         # Mock get_oldest_site to return a site
         mocker.patch("clerk.cli.get_oldest_site", return_value="old-site.civic.band")
 
@@ -198,7 +198,7 @@ class TestAutoEnqueueScheduler:
         )
 
     def test_update_next_exits_silently_when_no_eligible_sites(self, cli_runner, mocker):
-        """clerk update --next should exit gracefully if all sites recently updated."""
+        """clerk etl update --next should exit gracefully if all sites recently updated."""
         # Mock get_oldest_site to return None
         mocker.patch("clerk.cli.get_oldest_site", return_value=None)
 
@@ -214,7 +214,7 @@ class TestAutoEnqueueScheduler:
         mock_enqueue.assert_not_called()
 
     def test_update_subdomain_enqueues_with_high_priority(self, cli_runner, mocker):
-        """clerk update -s should enqueue specific site with high priority."""
+        """clerk etl update -s should enqueue specific site with high priority."""
         # Mock database check
         mock_conn = mocker.MagicMock()
         mock_conn.__enter__ = mocker.Mock(return_value=mock_conn)
@@ -243,7 +243,7 @@ class TestAutoEnqueueScheduler:
         )
 
     def test_update_requires_subdomain_or_next_flag(self, cli_runner):
-        """clerk update without flags should show usage error."""
+        """clerk etl update without flags should show usage error."""
         result = cli_runner.invoke(cli, ["update"])
 
         assert result.exit_code != 0
@@ -256,7 +256,7 @@ Run: `uv run pytest tests/test_cli.py::TestAutoEnqueueScheduler -v`
 
 Expected: FAIL - tests fail because update command doesn't have new logic yet
 
-**Step 3: Update `clerk update` command implementation**
+**Step 3: Update `clerk etl update` command implementation**
 
 Find the `update` command in `src/clerk/cli.py` (around line 370-395) and replace it with:
 
@@ -330,7 +330,7 @@ Expected: 4 tests PASS
 
 ```bash
 git add tests/test_cli.py src/clerk/cli.py
-git commit -m "feat: update clerk update command for auto-scheduling
+git commit -m "feat: update clerk etl update command for auto-scheduling
 
 - Add --next-site flag for auto-scheduler (normal priority)
 - Change -s/--subdomain to enqueue with high priority
@@ -641,7 +641,7 @@ The auto-scheduler ensures all sites update approximately once per day:
 
 ```bash
 # Run via cron every minute to auto-enqueue oldest site
-clerk update --next
+clerk etl update --next
 ```
 
 This command:
@@ -654,10 +654,10 @@ This command:
 
 **High priority** (processed first):
 - New sites: `clerk etl new <subdomain>`
-- Manual updates: `clerk update -s <subdomain>`
+- Manual updates: `clerk etl update -s <subdomain>`
 
 **Normal priority** (processed after high queue empty):
-- Auto-scheduler: `clerk update --next`
+- Auto-scheduler: `clerk etl update --next`
 - Bulk operations: `clerk enqueue site1 site2 site3`
 ```
 
@@ -675,7 +675,7 @@ To automatically update all sites once per day, set up a cron job:
 crontab -e
 
 # Add this line to run every minute:
-* * * * * cd /path/to/clerk && /path/to/uv run clerk update --next >> /var/log/clerk/auto-enqueue.log 2>&1
+* * * * * cd /path/to/clerk && /path/to/uv run clerk etl update --next >> /var/log/clerk/auto-enqueue.log 2>&1
 ```
 
 **Monitoring:**
@@ -706,7 +706,7 @@ Set up a cron job to automatically update all sites:
 
 ```bash
 # Run every minute to enqueue oldest site
-* * * * * cd /path/to/clerk && uv run clerk update --next
+* * * * * cd /path/to/clerk && uv run clerk etl update --next
 ```
 
 Manual operations use high priority and jump to the front of the queue:
@@ -716,7 +716,7 @@ Manual operations use high priority and jump to the front of the queue:
 clerk etl new new-city.civic.band
 
 # Manual update - high priority
-clerk update -s important-city.civic.band
+clerk etl update -s important-city.civic.band
 
 # Bulk enqueue - normal priority
 clerk enqueue site1 site2 site3
@@ -729,7 +729,7 @@ clerk enqueue site1 site2 site3
 git add docs/getting-started/basic-usage.md docs/deployment.md README.md
 git commit -m "docs: add auto-scheduler setup and usage instructions
 
-Document clerk update --next usage, cron setup, and priority model
+Document clerk etl update --next usage, cron setup, and priority model
 for manual vs automatic operations."
 ```
 
@@ -809,8 +809,8 @@ Create a completion summary in `docs/plans/2026-01-14-auto-enqueue-scheduler-com
 ## What Was Implemented
 
 ✅ `get_oldest_site()` helper function with tests
-✅ `clerk update --next` auto-scheduler mode (normal priority)
-✅ `clerk update -s <subdomain>` manual mode (high priority)
+✅ `clerk etl update --next` auto-scheduler mode (normal priority)
+✅ `clerk etl update -s <subdomain>` manual mode (high priority)
 ✅ `clerk etl new` auto-enqueues with high priority
 ✅ `clerk enqueue` verified to use normal priority default
 ✅ Integration tests for full workflow
@@ -819,8 +819,8 @@ Create a completion summary in `docs/plans/2026-01-14-auto-enqueue-scheduler-com
 ## Test Coverage
 
 - Unit tests: `get_oldest_site()` function (4 tests)
-- Unit tests: `clerk update --next` (2 tests)
-- Unit tests: `clerk update -s` (1 test)
+- Unit tests: `clerk etl update --next` (2 tests)
+- Unit tests: `clerk etl update -s` (1 test)
 - Unit tests: `clerk etl new` enqueue (1 test)
 - Unit tests: `clerk enqueue` priority (2 tests)
 - Integration test: Full workflow (1 test)
@@ -850,7 +850,7 @@ Create a completion summary in `docs/plans/2026-01-14-auto-enqueue-scheduler-com
 
 - [ ] PR approved and merged
 - [ ] Changes deployed to production
-- [ ] Cron job configured: `* * * * * cd /path && uv run clerk update --next`
+- [ ] Cron job configured: `* * * * * cd /path && uv run clerk etl update --next`
 - [ ] Log directory created: `/var/log/clerk/`
 - [ ] Verify cron is running: check logs after 1-2 minutes
 - [ ] Monitor queue status: `clerk status`

--- a/docs/plans/2026-01-16-documentation-overhaul-implementation.md
+++ b/docs/plans/2026-01-16-documentation-overhaul-implementation.md
@@ -903,7 +903,7 @@ Follow prompts to configure site.
 ### 2. Trigger an update
 
 ```bash
-clerk update -s test-city.civic.band
+clerk etl update -s test-city.civic.band
 ```
 
 ### 3. Monitor progress
@@ -1478,7 +1478,7 @@ Expected: One row showing your test site
 ### 3. Trigger Update
 
 ```bash
-clerk update -s test-verification.civic.band
+clerk etl update -s test-verification.civic.band
 ```
 
 Expected: Job enqueued message
@@ -2189,7 +2189,7 @@ pip install "clerk[pdf,extraction] @ git+https://github.com/civicband/clerk.git"
 clerk etl new
 
 # Update a site (enqueues fetch → OCR → compilation → deploy)
-clerk update --subdomain example.civic.band
+clerk etl update --subdomain example.civic.band
 
 # Check status
 clerk status

--- a/docs/plans/2026-01-16-documentation-overhaul-implementation.md
+++ b/docs/plans/2026-01-16-documentation-overhaul-implementation.md
@@ -895,7 +895,7 @@ Active Workers:
 ### 1. Create a test site
 
 ```bash
-clerk new test-city.civic.band
+clerk etl new test-city.civic.band
 ```
 
 Follow prompts to configure site.
@@ -1454,7 +1454,7 @@ Expected:
 ### 1. Create Test Site
 
 ```bash
-clerk new test-verification.civic.band
+clerk etl new test-verification.civic.band
 ```
 
 When prompted:
@@ -2186,7 +2186,7 @@ pip install "clerk[pdf,extraction] @ git+https://github.com/civicband/clerk.git"
 
 ```bash
 # Create a new site
-clerk new
+clerk etl new
 
 # Update a site (enqueues fetch → OCR → compilation → deploy)
 clerk update --subdomain example.civic.band

--- a/docs/plans/2026-01-17-synchronous-pipeline-test-mode.md
+++ b/docs/plans/2026-01-17-synchronous-pipeline-test-mode.md
@@ -382,13 +382,13 @@ Developer would immediately know something was wrong!
 
 ## Related Work
 
-- Old `clerk update` command (synchronous, but couldn't test queue workers)
+- Old `clerk etl update` command (synchronous, but couldn't test queue workers)
 - Queue worker pipeline (distributed, hard to test locally)
 - This bridges both: test queue workers synchronously
 
 ## Questions to Answer
 
-1. Should this replace `clerk update` entirely?
+1. Should this replace `clerk etl update` entirely?
 2. How to handle hooks that need external services (SSH, etc)?
 3. Should we mock external dependencies for testing?
 4. Integration with pytest for automated testing?

--- a/docs/plans/POSTGRES_MIGRATION.md
+++ b/docs/plans/POSTGRES_MIGRATION.md
@@ -28,11 +28,11 @@ The system automatically detects which database to use based on the `DATABASE_UR
 Example:
 ```bash
 # Development mode (SQLite)
-clerk new my-city --name "My City"
+clerk etl new my-city --name "My City"
 
 # Production mode (PostgreSQL)
 export DATABASE_URL="postgresql://user:pass@host:5432/civicband"
-clerk new my-city --name "My City"
+clerk etl new my-city --name "My City"
 ```
 
 ## Installation

--- a/docs/setup/single-machine.md
+++ b/docs/setup/single-machine.md
@@ -159,7 +159,7 @@ Active Workers:
 ### 1. Create a test site
 
 ```bash
-clerk new test-city.civic.band
+clerk etl new test-city.civic.band
 ```
 
 Follow prompts to configure site.

--- a/docs/setup/single-machine.md
+++ b/docs/setup/single-machine.md
@@ -167,7 +167,7 @@ Follow prompts to configure site.
 ### 2. Trigger an update
 
 ```bash
-clerk update -s test-city.civic.band
+clerk etl update -s test-city.civic.band
 ```
 
 ### 3. Monitor progress

--- a/docs/setup/verification.md
+++ b/docs/setup/verification.md
@@ -46,7 +46,7 @@ Expected:
 ### 1. Create Test Site
 
 ```bash
-clerk new test-verification.civic.band
+clerk etl new test-verification.civic.band
 ```
 
 When prompted:

--- a/docs/setup/verification.md
+++ b/docs/setup/verification.md
@@ -70,7 +70,7 @@ Expected: One row showing your test site
 ### 3. Trigger Update
 
 ```bash
-clerk update -s test-verification.civic.band
+clerk etl update -s test-verification.civic.band
 ```
 
 Expected: Job enqueued message


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fix incorrect CLI command in documentation from clerk new to clerk etl new. Running clerk new would previously produce Error: No such command 'new'.  This makes similar updates for `clerk update` -> `clerk etl update`.  

This is just a simple find/replace that mostly targets documentation files; it also updates a non-functional sh template file which has not been tested.

## PR Checklist

<!--- If existing, please state which site -->
New site, or existing?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the CivicBand Code of Conduct
- [x] I will abide by the CivicBand Contributor Guide
- [ ] This PR was generated or assisted using an AI tool
<!-- AI assistance is allowed, but must be marked -->
<!-- update or delete the next line to reflect your usage -->
