### PR TITLE
docs: Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,25 +32,13 @@ pip install "civicband-clerk[pdf,extraction] @ git+https://github.com/civicband/
 - **[Distributed Workers](docs/setup/distributed.md)** - Scale across multiple machines
 - **[Verification](docs/setup/verification.md)** - Test your setup
 
-### Operations
+### Getting Started
 
-- **[Daily Tasks](docs/operations/daily-tasks.md)** - Common operational tasks
-- **[Monitoring](docs/operations/monitoring.md)** - Health checks and metrics
-- **[Troubleshooting](docs/operations/troubleshooting.md)** - Fix common issues
-- **[Scaling](docs/operations/scaling.md)** - Add workers and scale horizontally
-
-### Reference
-
-- **[CLI Reference](docs/reference/cli/index.md)** - Complete command-line reference
-- **[Python API](docs/reference/python-api/index.md)** - Python library reference
-- **[Plugin API](docs/reference/plugin-api/index.md)** - Plugin development guide
-
-### Guides
-
-- **[Your First Site](docs/guides/first-site.md)** - Complete beginner tutorial
-- **[Worker Architecture](docs/guides/worker-architecture.md)** - Understanding task queues
-- **[Custom Fetcher](docs/guides/custom-fetcher.md)** - Build a fetcher plugin
-- **[Production Checklist](docs/guides/production-checklist.md)** - Pre-launch validation
+- **[Installation](docs/setup/prerequisites.md)** - System requirements and setup
+- **[macOS Setup](docs/setup/macos.md)** - Installation on macOS
+- **[Linux Setup](docs/setup/linux.md)** - Installation on Linux
+- **[Distributed Setup](docs/setup/distributed.md)** - Multi-machine worker configuration
+- **[Verification](docs/setup/verification.md)** - Verify your installation
 
 ## Quick Start
 
@@ -61,11 +49,12 @@ clerk etl new
 # Update a site (enqueues fetch → OCR → compilation → deploy)
 clerk etl update --subdomain example.civic.band
 
-# Check status
-clerk status
+# Start workers to process the pipeline (in another terminal)
+clerk worker fetch &
+clerk worker ocr &
+clerk worker compilation &
+clerk worker deploy &
 ```
-
-See [Your First Site Tutorial](docs/guides/first-site.md) for a complete walkthrough.
 
 ## Architecture
 
@@ -77,9 +66,7 @@ Clerk uses a distributed task queue (RQ) with specialized worker types:
 - **extraction** - Entity and vote extraction (optional, memory-intensive)
 - **deploy** - Upload to storage/CDN
 
-Workers can run on a single machine or distributed across multiple machines for better performance.
-
-See [Worker Architecture Guide](docs/guides/worker-architecture.md) for details.
+Workers can run on a single machine or distributed across multiple machines for better performance. See [Distributed Setup](docs/setup/distributed.md) for details.
 
 ## Contributing
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,10 +1,10 @@
 # Deployment Guide
 
-Guide for deploying clerk in production with automated updates.
+**⚠️ Note:** The automated deployment features (`clerk install-launchd`, `clerk install-workers`) described in this guide are not yet implemented. For production deployments, use your system's standard process manager (systemd, launchd, supervisor, etc.) to manage clerk worker processes. See [Single-Machine Setup](docs/setup/single-machine.md) for manual worker management.
 
 ## Overview
 
-Clerk provides built-in support for automated updates using macOS's launchd system. The `clerk install-launchd` command sets up scheduled jobs that:
+This guide describes the planned automated deployment workflow. For current production deployments:
 
 - Run `clerk etl update -n` every 60 seconds
 - Monitor for failures and send alerts
@@ -312,8 +312,8 @@ crontab -e
 # View auto-enqueue log
 tail -f /var/log/clerk/auto-enqueue.log
 
-# Check queue status
-clerk status
+# Check Redis queue status (if available)
+redis-cli INFO stats
 ```
 
 The auto-scheduler:

--- a/docs/setup/distributed.md
+++ b/docs/setup/distributed.md
@@ -177,46 +177,43 @@ psql postgresql://user:pass@SERVICE_HOST:5432/clerk_civic -c "SELECT 1;"
 
 Expected: Both commands succeed
 
-### 4. Install and Start Workers
+### 4. Start Workers on Each Machine
 
 **On each machine:**
 
 ```bash
-# Install worker services
-clerk install-workers
+# Start workers in tmux/screen or as background processes
+# Terminal 1: Fetch workers
+clerk worker fetch -n 2
 
-# Start workers (macOS)
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/clerk.worker.*.plist
+# Terminal 2: OCR workers
+clerk worker ocr -n 8
 
-# Start workers (Linux)
-systemctl --user enable clerk-worker-*
-systemctl --user start clerk-worker-*
+# Terminal 3: Compilation workers (core pipeline only)
+clerk worker compilation -n 2
+
+# Terminal 4: Deploy workers
+clerk worker deploy -n 1
+
+# Terminal 5: Extraction workers (if EXTRACTION_WORKERS > 0)
+clerk worker extraction -n 2
 ```
+
+For production, use systemd services or equivalent to manage worker processes.
 
 ### 5. Verify Distributed Setup
 
-**From any machine:**
+**From any machine, check Redis queue depths:**
 
 ```bash
-clerk status
+redis-cli LLEN rq:queue:fetch
+redis-cli LLEN rq:queue:ocr
+redis-cli LLEN rq:queue:compilation
+redis-cli LLEN rq:queue:extraction
+redis-cli LLEN rq:queue:deploy
 ```
 
-Expected output showing workers from all machines:
-```
-Queue Status:
-  fetch: 0 jobs
-  ocr: 0 jobs
-  compilation: 0 jobs
-  extraction: 0 jobs
-  deploy: 0 jobs
-
-Active Workers:
-  fetch: 2 workers
-  ocr: 8 workers
-  compilation: 2 workers
-  extraction: 2 workers
-  deploy: 1 worker
-```
+Expected: All queues return 0 or a count (indicates Redis is responsive)
 
 ## Storage Considerations
 
@@ -297,26 +294,19 @@ See [Operations: Monitoring](../operations/monitoring.md) for detailed log queri
 
 **Option 1: Add workers to existing machine**
 
-Edit `.env` to increase worker counts:
+Stop the current worker process and restart with higher worker count:
 
 ```bash
-OCR_WORKERS=16  # Was 8
-```
-
-Reinstall workers:
-
-```bash
-clerk uninstall-workers
-clerk install-workers
+pkill -f "clerk worker ocr"
+clerk worker ocr -n 16  # Was -n 8
 ```
 
 **Option 2: Add new worker machine**
 
 1. Install Clerk on new machine
 2. Configure `.env` with shared services
-3. Set worker counts (only desired worker types)
-4. Install and start workers
-5. Verify with `clerk status`
+3. Start worker processes with desired counts
+4. Verify with `redis-cli LLEN rq:queue:*` commands
 
 ## Next Steps
 

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -5,11 +5,11 @@ Complete installation guide for Clerk on Linux.
 ## Prerequisites
 
 Before starting, complete [Prerequisites](prerequisites.md) to install:
-- Redis
-- PostgreSQL
-- Tesseract
-- Poppler
-- Python 3.12+
+- Redis (required)
+- Tesseract (required)
+- Poppler (required)
+- Python 3.12+ (required)
+- SQLite (required)
 
 ## Installation
 
@@ -65,12 +65,12 @@ python3.12 -m spacy download en_core_web_md
 
 ### 4. Configure Environment
 
-Create `.env` file:
+Create `.env` file (using SQLite by default):
 
 ```bash
 cat > .env <<'EOF'
 STORAGE_DIR=../sites
-DATABASE_URL=postgresql://localhost/clerk_civic
+DATABASE_URL=sqlite:///civic.db
 REDIS_URL=redis://localhost:6379
 DEFAULT_OCR_BACKEND=tesseract
 ENABLE_EXTRACTION=0
@@ -80,6 +80,11 @@ COMPILATION_WORKERS=2
 EXTRACTION_WORKERS=0
 DEPLOY_WORKERS=1
 EOF
+```
+
+**For PostgreSQL (production)**, use instead:
+```bash
+DATABASE_URL=postgresql://localhost/clerk_civic
 ```
 
 ### 5. Add Clerk to PATH
@@ -109,13 +114,18 @@ Check Clerk version:
 clerk --version
 ```
 
-Check database connection:
+Check database connection (SQLite):
 
 ```bash
-psql $DATABASE_URL -c "SELECT COUNT(*) FROM sites;"
+sqlite3 civic.db "SELECT COUNT(*) FROM sites;"
 ```
 
 Expected: `0` (empty table)
+
+**If using PostgreSQL**, check with:
+```bash
+psql $DATABASE_URL -c "SELECT COUNT(*) FROM sites;"
+```
 
 Check Redis connection:
 
@@ -150,7 +160,14 @@ source ~/.bashrc
 
 **Database connection failed**
 
-Fix: Ensure PostgreSQL is running:
+If using SQLite (default), ensure the file is writable:
+
+```bash
+touch civic.db
+chmod 644 civic.db
+```
+
+If using PostgreSQL (production), ensure it's running:
 
 ```bash
 sudo systemctl status postgresql

--- a/docs/setup/macos.md
+++ b/docs/setup/macos.md
@@ -5,11 +5,11 @@ Complete installation guide for Clerk on macOS.
 ## Prerequisites
 
 Before starting, complete [Prerequisites](prerequisites.md) to install:
-- Redis
-- PostgreSQL
-- Tesseract
-- Poppler
-- Python 3.12+
+- Redis (required)
+- Tesseract (required)
+- Poppler (required)
+- Python 3.12+ (required)
+- SQLite (required)
 
 ## Installation
 
@@ -41,12 +41,12 @@ python -m spacy download en_core_web_md
 
 ### 3. Configure Environment
 
-Create `.env` file:
+Create `.env` file (using SQLite by default):
 
 ```bash
 cat > .env <<'EOF'
 STORAGE_DIR=../sites
-DATABASE_URL=postgresql://localhost/clerk_civic
+DATABASE_URL=sqlite:///civic.db
 REDIS_URL=redis://localhost:6379
 DEFAULT_OCR_BACKEND=tesseract
 ENABLE_EXTRACTION=0
@@ -56,6 +56,11 @@ COMPILATION_WORKERS=2
 EXTRACTION_WORKERS=0
 DEPLOY_WORKERS=1
 EOF
+```
+
+**For PostgreSQL (production)**, use instead:
+```bash
+DATABASE_URL=postgresql://localhost/clerk_civic
 ```
 
 ### 4. Initialize Database
@@ -78,13 +83,18 @@ Check Clerk version:
 clerk --version
 ```
 
-Check database connection:
+Check database connection (SQLite):
 
 ```bash
-psql $DATABASE_URL -c "SELECT COUNT(*) FROM sites;"
+sqlite3 civic.db "SELECT COUNT(*) FROM sites;"
 ```
 
 Expected: `0` (empty table)
+
+**If using PostgreSQL**, check with:
+```bash
+psql $DATABASE_URL -c "SELECT COUNT(*) FROM sites;"
+```
 
 Check Redis connection:
 
@@ -93,20 +103,6 @@ redis-cli ping
 ```
 
 Expected: `PONG`
-
-## Optional: Vision Framework OCR
-
-For faster OCR on Apple Silicon:
-
-```bash
-pip install pyobjc-framework-Vision pyobjc-framework-Quartz
-```
-
-Update `.env`:
-
-```bash
-DEFAULT_OCR_BACKEND=vision
-```
 
 ## Next Steps
 
@@ -131,7 +127,14 @@ export PATH="$HOME/.local/bin:$PATH"
 
 **Database connection failed**
 
-Fix: Ensure PostgreSQL is running:
+If using SQLite (default), ensure the file is writable:
+
+```bash
+touch civic.db
+chmod 644 civic.db
+```
+
+If using PostgreSQL (production), ensure it's running:
 
 ```bash
 brew services start postgresql@15

--- a/docs/setup/prerequisites.md
+++ b/docs/setup/prerequisites.md
@@ -29,7 +29,7 @@ System requirements for running Clerk.
 
 ### Redis
 
-Task queue backend.
+Task queue backend for job processing.
 
 **macOS:**
 ```bash
@@ -51,9 +51,11 @@ redis-cli ping
 
 Expected: `PONG`
 
-### PostgreSQL
+## Optional Services
 
-Central database for site metadata and job tracking.
+### PostgreSQL (Production Only)
+
+For production deployments with multiple servers, you can use PostgreSQL instead of SQLite for the central database. SQLite is the default and recommended for single-machine setups.
 
 **macOS:**
 ```bash
@@ -135,7 +137,7 @@ brew install pango cairo glib gobject-introspection
 sudo apt install libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev
 ```
 
-**Note:** On macOS, the `clerk install-workers` command automatically configures the library path for these dependencies. If running clerk manually, you may need to set:
+**Note:** On macOS, you may need to set the library path for these dependencies:
 
 ```bash
 export DYLD_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_LIBRARY_PATH"  # Apple Silicon
@@ -159,8 +161,12 @@ Create `.env` file in your working directory:
 # Storage directory for site data
 STORAGE_DIR=../sites
 
-# Database connection
-DATABASE_URL=postgresql://localhost/clerk_civic
+# Database connection (SQLite is default, PostgreSQL is optional)
+# SQLite (development/single-machine - no setup required):
+DATABASE_URL=sqlite:///civic.db
+
+# PostgreSQL (production/distributed - optional):
+# DATABASE_URL=postgresql://localhost/clerk_civic
 
 # Redis connection
 REDIS_URL=redis://localhost:6379

--- a/docs/setup/single-machine.md
+++ b/docs/setup/single-machine.md
@@ -53,61 +53,36 @@ EXTRACTION_WORKERS=0  # Set to 0 if not using extraction
 - Each extraction worker: ~5 GB (with spaCy)
 - Recommended: 8 GB RAM for full pipeline
 
-### 2. Install Worker Services
+### 2. Start Workers Manually
 
-**macOS (LaunchAgents):**
-
-```bash
-clerk install-workers
-```
-
-This creates LaunchAgent plist files in `~/Library/LaunchAgents/` for each worker type.
-
-**Verify installation:**
+Start each worker type in separate terminal windows:
 
 ```bash
-ls ~/Library/LaunchAgents/ | grep clerk
+# Terminal 1: Fetch worker
+clerk worker fetch
+
+# Terminal 2: OCR workers
+clerk worker ocr -n 4
+
+# Terminal 3: Compilation worker
+clerk worker compilation
+
+# Terminal 4: Deploy worker  
+clerk worker deploy
 ```
 
-Expected: Multiple `clerk.worker.*.plist` files
-
-**Linux (systemd):**
+Or run all in the background:
 
 ```bash
-clerk install-workers
+clerk worker fetch &
+clerk worker ocr -n 4 &
+clerk worker compilation &
+clerk worker deploy &
 ```
 
-This creates systemd service files in `~/.config/systemd/user/` for each worker.
+For production deployments, use your system's process manager (systemd, launchd, supervisor, etc.) to manage worker processes.
 
-**Verify installation:**
-
-```bash
-systemctl --user list-unit-files | grep clerk
-```
-
-Expected: Multiple `clerk-worker-*.service` files
-
-### 3. Start Workers
-
-**macOS:**
-
-```bash
-# Start all workers
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/clerk.worker.*.plist
-
-# Or restart if already loaded
-launchctl kickstart gui/$(id -u)/clerk.worker.fetch.1
-```
-
-**Linux:**
-
-```bash
-# Enable and start all workers
-systemctl --user enable clerk-worker-*
-systemctl --user start clerk-worker-*
-```
-
-### 4. Verify Workers Running
+### 3. Verify Workers Running
 
 **Check worker processes:**
 
@@ -115,44 +90,18 @@ systemctl --user start clerk-worker-*
 ps aux | grep "clerk worker"
 ```
 
-Expected: One process per configured worker
+Expected: One process per worker (fetch, ocr, compilation, deploy)
 
-**Check worker status:**
-
-**macOS:**
+**Check Redis queues:**
 
 ```bash
-launchctl print gui/$(id -u)/clerk.worker.fetch.1
+redis-cli LLEN rq:queue:fetch
+redis-cli LLEN rq:queue:ocr
+redis-cli LLEN rq:queue:compilation
+redis-cli LLEN rq:queue:deploy
 ```
 
-**Linux:**
-
-```bash
-systemctl --user status clerk-worker-fetch-1
-```
-
-**Use clerk status command:**
-
-```bash
-clerk status
-```
-
-Expected output:
-```
-Queue Status:
-  fetch: 0 jobs
-  ocr: 0 jobs
-  compilation: 0 jobs
-  extraction: 0 jobs
-  deploy: 0 jobs
-
-Active Workers:
-  fetch: 2 workers
-  ocr: 4 workers
-  compilation: 2 workers
-  extraction: 0 workers
-  deploy: 1 worker
-```
+Expected: All return 0 or a number (indicates Redis is working)
 
 ## Testing the Pipeline
 
@@ -174,22 +123,21 @@ clerk etl update -s test-city.civic.band
 
 ```bash
 # Watch queue depths
-watch -n 2 clerk status
+watch -n 2 "redis-cli LLEN rq:queue:fetch; redis-cli LLEN rq:queue:ocr; redis-cli LLEN rq:queue:compilation"
 
-# Or follow logs (macOS)
-tail -f /tmp/clerk.worker.fetch.1.log
-
-# Or follow logs (Linux)
-journalctl --user -u clerk-worker-fetch-1 -f
+# Or follow worker output (if running in foreground)
+# Just watch the terminal where you started the workers
 ```
 
 ### 4. Verify completion
 
+Check the storage directory for output:
+
 ```bash
-clerk status -s test-city.civic.band
+ls ../sites/test-city.civic.band/
 ```
 
-Expected: Site shows "completed" status
+Expected: Contains `pdfs/`, `txt/`, and `meetings.db`
 
 ## Next Steps
 
@@ -203,40 +151,27 @@ See [Setup Troubleshooting](troubleshooting.md) for common issues.
 
 ### Workers not starting
 
-**macOS:**
-
-Check LaunchAgent logs:
-
-```bash
-cat /tmp/clerk.worker.fetch.1.log
-```
-
-**Linux:**
-
-Check systemd logs:
-
-```bash
-journalctl --user -u clerk-worker-fetch-1 -n 50
-```
+Check the terminal where you started the workers for error messages.
 
 Common fixes:
 - Ensure Redis is running: `redis-cli ping`
 - Ensure PostgreSQL is running: `psql $DATABASE_URL -c "SELECT 1;"`
-- Check PATH in LaunchAgent/systemd files
 - Verify `.env` file exists and is readable
+- Check that the `STORAGE_DIR` exists and is writable
 
 ### Jobs stuck in queue
 
-Check worker logs for errors:
+Check if workers are running and check for errors in their output:
 
 ```bash
-clerk diagnose-workers
+# List all worker processes
+ps aux | grep "clerk worker"
+
+# Check Redis for stuck jobs
+redis-cli LRANGE rq:queue:fetch 0 -1
 ```
 
-This command shows:
-- Worker process status
-- Recent log output
-- Configuration issues
+Look at the worker output/logs for error messages about why jobs aren't completing.
 
 ### High memory usage
 

--- a/docs/setup/troubleshooting.md
+++ b/docs/setup/troubleshooting.md
@@ -88,7 +88,25 @@ Should be: `REDIS_URL=redis://localhost:6379`
 sudo ufw allow 6379/tcp
 ```
 
-### PostgreSQL connection failed
+### Database connection failed (SQLite or PostgreSQL)
+
+**If using SQLite (default):**
+
+**Symptom:** `Error: unable to open database file`
+
+**Fix:**
+
+```bash
+# Ensure the database file is writable
+touch civic.db
+chmod 644 civic.db
+
+# Verify it's being used
+grep DATABASE_URL .env
+# Should show: DATABASE_URL=sqlite:///civic.db
+```
+
+**If using PostgreSQL (production):**
 
 **Symptom:** `Error: could not connect to server`
 
@@ -140,52 +158,31 @@ Should be: `DATABASE_URL=postgresql://localhost/clerk_civic`
 
 ### Workers not starting
 
-**Symptom:** `clerk status` shows 0 workers
+**Symptom:** No worker processes running (`ps aux | grep "clerk worker"` shows nothing)
 
-**Diagnosis (macOS):**
-
-```bash
-launchctl list | grep clerk
-cat /tmp/clerk.worker.fetch.1.log
-```
-
-**Diagnosis (Linux):**
+**Diagnosis:**
 
 ```bash
-systemctl --user status clerk-worker-fetch-1
-journalctl --user -u clerk-worker-fetch-1 -n 50
+# Check if worker process is running
+ps aux | grep "clerk worker"
+
+# Try starting a worker and see error
+clerk worker fetch
+
+# Check Redis connectivity
+redis-cli ping
 ```
 
-**Fix (LaunchAgent not loaded - macOS):**
+**Fix (Redis not running):**
 
 ```bash
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/clerk.worker.*.plist
-```
+# macOS
+brew services start redis
+redis-cli ping
 
-**Fix (systemd service not enabled - Linux):**
-
-```bash
-systemctl --user enable clerk-worker-*
-systemctl --user start clerk-worker-*
-```
-
-**Fix (PATH issue in LaunchAgent):**
-
-Edit `~/Library/LaunchAgents/clerk.worker.fetch.1.plist`:
-
-```xml
-<key>EnvironmentVariables</key>
-<dict>
-    <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
-</dict>
-```
-
-Reload:
-
-```bash
-launchctl bootout gui/$(id -u)/clerk.worker.fetch.1
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/clerk.worker.fetch.1.plist
+# Linux
+sudo systemctl start redis-server
+sudo systemctl enable redis-server
 ```
 
 **Fix (missing .env file):**
@@ -193,9 +190,24 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/clerk.worker.fetch.1.pli
 ```bash
 # Ensure .env exists in working directory
 ls -la .env
+
+# If missing, create it with required variables
+cat > .env <<EOF
+DATABASE_URL=sqlite:///civic.db
+REDIS_URL=redis://localhost:6379
+STORAGE_DIR=../sites
+EOF
 ```
 
-See [Prerequisites](prerequisites.md) for .env template.
+**Fix (wrong PATH):**
+
+Ensure clerk is in your PATH:
+
+```bash
+which clerk
+# If not found, use full path:
+/usr/local/bin/clerk worker fetch
+```
 
 ### Workers crash immediately
 
@@ -242,8 +254,13 @@ Check Redis is running and .env has correct REDIS_URL.
 **Diagnosis:**
 
 ```bash
-clerk status
+# Check queue depths
+redis-cli LLEN rq:queue:fetch
+redis-cli LLEN rq:queue:ocr
 redis-cli LLEN rq:queue:failed
+
+# Check for failed jobs
+redis-cli LRANGE rq:queue:failed 0 -1
 ```
 
 **Fix (workers not running):**
@@ -252,26 +269,18 @@ See "Workers not starting" above.
 
 **Fix (failed jobs):**
 
-View failed jobs:
+View details of failed jobs:
 
 ```bash
 redis-cli LRANGE rq:queue:failed 0 -1
 ```
 
-Clear failed queue:
+This will show job IDs. Look at worker logs for error messages.
+
+Clear failed queue (only if you understand why they failed):
 
 ```bash
 redis-cli DEL rq:queue:failed
-```
-
-**Fix (deadlock - job depends on failed job):**
-
-```bash
-# Purge all jobs for a site
-clerk purge -s SUBDOMAIN
-
-# Or purge entire queue
-clerk purge-queue fetch
 ```
 
 ### Jobs fail with errors
@@ -320,15 +329,14 @@ sudo apt install poppler-utils
 
 **`MemoryError` during extraction:**
 
-Reduce extraction workers or disable extraction:
+Disable extraction:
 
 ```bash
 # Edit .env
-EXTRACTION_WORKERS=0  # Or reduce to 1
+ENABLE_EXTRACTION=0
 
-# Restart workers
-clerk uninstall-workers
-clerk install-workers
+# Stop extraction workers
+pkill -f "clerk worker extraction"
 ```
 
 ## Performance Issues
@@ -338,32 +346,21 @@ clerk install-workers
 **Diagnosis:**
 
 ```bash
-time clerk ocr -s SUBDOMAIN --force
+time clerk etl ocr
 ```
 
 If > 10 seconds per page, investigate:
 
-**Fix (using Vision Framework on non-Apple Silicon):**
-
-Switch to Tesseract:
-
-```bash
-# Edit .env
-DEFAULT_OCR_BACKEND=tesseract
-
-# Re-run OCR
-clerk ocr -s SUBDOMAIN --force
-```
-
 **Fix (too few OCR workers):**
 
-```bash
-# Edit .env
-OCR_WORKERS=8  # Increase from 4
+Stop existing workers and restart with more:
 
-# Restart workers
-clerk uninstall-workers
-clerk install-workers
+```bash
+# Stop OCR workers
+pkill -f "clerk worker ocr"
+
+# Start with more workers
+clerk worker ocr -n 8 &
 ```
 
 ### High memory usage
@@ -377,62 +374,35 @@ clerk install-workers
 ps aux | grep "clerk worker" | awk '{print $4, $11}'
 ```
 
-**Fix (extraction workers using too much RAM):**
+**Fix (disable extraction):**
 
-Disable or reduce extraction workers:
+Disable extraction entirely:
 
 ```bash
 # Edit .env
-EXTRACTION_WORKERS=0  # Or set to 1
+ENABLE_EXTRACTION=0
 
-# Restart workers
-clerk uninstall-workers
-clerk install-workers
+# Stop extraction workers
+pkill -f "clerk worker extraction"
 ```
 
 Use distributed setup to run extraction on separate machine:
 
 See [Distributed Setup](distributed.md).
 
-**Fix (reduce spaCy parallel processing):**
-
-```bash
-# Edit .env
-SPACY_N_PROCESS=1  # Default is 2
-
-# Restart extraction workers
-systemctl --user restart clerk-worker-extraction-*
-```
-
 ## Diagnostic Tools
 
-### clerk diagnose-workers
-
-Comprehensive worker diagnostics:
+### Check Worker Status
 
 ```bash
-clerk diagnose-workers
+# List all running worker processes
+ps aux | grep "clerk worker"
+
+# Check if workers are listening to queues
+redis-cli KEYS "rq:worker:*"
 ```
 
-Shows:
-- Worker process status
-- LaunchAgent/systemd configuration
-- Recent log output
-- Configuration issues
-
-### clerk status
-
-Queue and job status:
-
-```bash
-# Overall status
-clerk status
-
-# Site-specific status
-clerk status -s SUBDOMAIN
-```
-
-### Manual Redis inspection
+### Queue and Job Inspection
 
 ```bash
 # List all queues
@@ -440,9 +410,15 @@ redis-cli KEYS "rq:queue:*"
 
 # Check queue length
 redis-cli LLEN rq:queue:fetch
+redis-cli LLEN rq:queue:ocr
+redis-cli LLEN rq:queue:compilation
 
-# View jobs in queue
-redis-cli LRANGE rq:queue:fetch 0 -1
+# View jobs in queue (show first 10)
+redis-cli LRANGE rq:queue:fetch 0 10
+
+# Check for failed jobs
+redis-cli LLEN rq:queue:failed
+redis-cli LRANGE rq:queue:failed 0 -1
 ```
 
 ## Getting More Help
@@ -455,7 +431,8 @@ If troubleshooting doesn't resolve your issue:
    - Platform (macOS/Linux)
    - Clerk version (`clerk --version`)
    - Full error messages
-   - Output from `clerk diagnose-workers`
+   - Output from `ps aux | grep "clerk worker"`
+   - Queue status from Redis
    - Relevant log files
 
 ## Next Steps

--- a/docs/setup/verification.md
+++ b/docs/setup/verification.md
@@ -22,24 +22,36 @@ redis-cli ping
 
 Expected: `PONG`
 
-**PostgreSQL:**
+**SQLite Database:**
+
+```bash
+sqlite3 civic.db "SELECT COUNT(*) FROM sites;"
+```
+
+Expected: `0` (empty table)
+
+**PostgreSQL (if configured):**
 
 ```bash
 psql $DATABASE_URL -c "SELECT COUNT(*) FROM sites;"
 ```
 
-Expected: `0` (empty table)
-
 ### 3. Check Worker Status
 
 ```bash
-clerk status
+# Check if workers are running
+ps aux | grep "rq worker"
+
+# Check queue status in Redis
+redis-cli --raw LLEN rq:queue:fetch
+redis-cli --raw LLEN rq:queue:ocr
+redis-cli --raw LLEN rq:queue:compilation
+redis-cli --raw LLEN rq:queue:deploy
 ```
 
 Expected:
-- All configured queues listed
-- Worker counts match your configuration
-- No errors in output
+- Worker processes listed
+- Queue lengths return 0 or numbers (indicates Redis is responsive)
 
 ## End-to-End Test
 
@@ -61,11 +73,15 @@ When prompted:
 
 ### 2. Verify Site Created
 
+Using SQLite:
+
 ```bash
-psql $DATABASE_URL -c "SELECT subdomain, name FROM sites WHERE subdomain='test-verification.civic.band';"
+sqlite3 civic.db "SELECT subdomain, name FROM sites WHERE subdomain='test-verification.civic.band';"
 ```
 
 Expected: One row showing your test site
+
+(If using PostgreSQL, use `psql` instead of `sqlite3`)
 
 ### 3. Trigger Update
 
@@ -77,16 +93,19 @@ Expected: Job enqueued message
 
 ### 4. Monitor Queue
 
+Monitor the queue status:
+
 ```bash
-watch -n 2 "clerk status -s test-verification.civic.band"
+# Watch the queue depths (update every second)
+watch -n 1 "redis-cli --raw LLEN rq:queue:fetch; redis-cli --raw LLEN rq:queue:ocr; redis-cli --raw LLEN rq:queue:compilation; redis-cli --raw LLEN rq:queue:deploy"
 ```
 
 Watch for:
-1. Job appears in fetch queue
-2. Job moves to OCR queue
-3. Job moves to compilation queue
-4. Job moves to deploy queue
-5. Site status becomes "completed"
+1. Job appears in fetch queue (LLEN > 0)
+2. Queue lengths decrease as jobs process
+3. All queues return to 0 when complete
+
+If workers are running in foreground terminals, watch their stdout output for any errors.
 
 Press Ctrl+C when complete.
 
@@ -156,7 +175,10 @@ Expected: No error messages
 
 ```bash
 # Check queue lengths
-clerk status | grep -E "fetch|ocr|compilation"
+redis-cli --raw LLEN rq:queue:fetch
+redis-cli --raw LLEN rq:queue:ocr
+redis-cli --raw LLEN rq:queue:compilation
+redis-cli --raw LLEN rq:queue:deploy
 
 # Check for failed jobs
 redis-cli LLEN rq:queue:failed
@@ -166,27 +188,29 @@ Expected: All queues at 0 or decreasing, no failed jobs
 
 ## Performance Tests
 
-### Test OCR Speed
+### Test OCR Performance
 
-Time a single PDF:
-
-```bash
-time clerk ocr -s test-verification.civic.band --force
-```
-
-Expected: Completes without errors
-
-Typical speeds:
-- Tesseract: 2-5 seconds per page
-- Vision Framework: 0.5-1 second per page
-
-### Test Database Build Speed
+Monitor OCR queue processing time:
 
 ```bash
-time clerk build-db-from-text -s test-verification.civic.band
+# Time from when you enqueue to when queue returns to 0
+time (
+  clerk etl update -s test-verification.civic.band
+  until [ $(redis-cli LLEN rq:queue:ocr) -eq 0 ]; do sleep 1; done
+)
 ```
 
-Expected: Completes without errors
+Typical speeds with Tesseract: 2-5 seconds per page
+
+### Test Compilation Performance
+
+Monitor compilation time:
+
+```bash
+# After OCR completes, time the compilation
+redis-cli LLEN rq:queue:compilation
+# Wait for compilation queue to process
+```
 
 Typical speeds:
 - Without extraction: 10-30 seconds for 100 pages
@@ -197,7 +221,8 @@ Typical speeds:
 - [ ] `clerk --version` shows version number
 - [ ] `redis-cli ping` returns PONG
 - [ ] `psql $DATABASE_URL` connects successfully
-- [ ] `clerk status` shows configured workers
+- [ ] Worker processes are running (`ps aux | grep "rq worker"`)
+- [ ] Redis queues are accessible
 - [ ] Test site creation succeeds
 - [ ] Test site update completes end-to-end
 - [ ] PDFs downloaded to storage directory

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -28,11 +28,11 @@ See the [complete task queue documentation](task-queue.md) for installation, con
 
 The [Monitoring Guide](monitoring.md) covers health checking and observability for your clerk pipeline:
 
-- `clerk health` command for system health checks
-- Queue depth monitoring and thresholds
-- Worker status and failed job tracking
-- Integration with monitoring systems (Nagios, Prometheus)
-- Job completion verification and debugging
+- Redis queue depth monitoring
+- Worker process monitoring
+- Database health checks
+- Failed job tracking and debugging
+- Integration with monitoring systems (Prometheus, cron)
 
 See the [monitoring documentation](monitoring.md) for detailed usage and troubleshooting.
 

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -1,339 +1,286 @@
 # Monitoring Your Clerk Pipeline
 
-This guide covers monitoring and health checking for your clerk pipeline.
+This guide covers monitoring and health checking for your clerk pipeline using Redis commands and system tools.
 
-## Health Check Command
+## Quick Health Check
 
-The `clerk health` command provides a comprehensive health check of your clerk pipeline, checking Redis connectivity, PostgreSQL connectivity, queue depths, worker status, and failed jobs.
-
-### Basic Usage
+### Check Service Connectivity
 
 ```bash
-# Quick health check
-clerk health
+# Redis
+redis-cli ping
+# Expected: PONG
 
-# Detailed output with verbose logging
-clerk health --verbose
+# SQLite (default)
+sqlite3 civic.db "SELECT COUNT(*) FROM sites;"
+# Expected: A number
 
-# JSON output for monitoring systems
-clerk health --json
+# PostgreSQL (if configured)
+psql $DATABASE_URL -c "SELECT COUNT(*) FROM sites;"
+# Expected: A number
 ```
 
-### Exit Codes
-
-The command returns different exit codes for automation:
-
-- **0**: System healthy - all checks passed
-- **1**: System degraded - warnings present but system operational
-- **2**: System unhealthy - critical errors detected
-
-### What Gets Checked
-
-The health command performs the following checks:
-
-#### 1. Redis Connectivity
-Verifies Redis is accessible and responsive.
-
-**Critical**: If Redis is down, no jobs can be enqueued or processed.
-
-#### 2. PostgreSQL Connectivity
-Verifies PostgreSQL civic.db database is accessible.
-
-**Critical**: If PostgreSQL is down, job tracking and site metadata is unavailable.
-
-#### 3. Queue Depths
-Checks the number of pending jobs in each queue and compares against thresholds:
-
-| Queue | Warning Threshold | Critical Threshold |
-|-------|------------------|-------------------|
-| high | 50 | 100 |
-| fetch | 25 | 50 |
-| ocr | 250 | 500 |
-| compilation | 50 | 100 |
-| extraction | 50 | 100 |
-| deploy | 25 | 50 |
-
-**Warning**: If queue depth exceeds warning threshold, you may need to scale workers.
-
-**Critical**: If queue depth exceeds critical threshold, the system is likely overloaded.
-
-#### 4. Worker Status
-Checks the number of workers by status:
-
-- **Total workers**: Total number of registered workers
-- **Active workers**: Workers currently processing jobs
-- **Busy workers**: Workers that are occupied
-- **Idle workers**: Workers waiting for jobs
-
-**Warning**: If idle workers is 0, all workers are busy and new jobs will queue.
-
-#### 5. Failed Jobs
-Counts the number of failed jobs in the last 24 hours.
-
-**Warning**: More than 5 failed jobs indicates potential issues.
-
-**Critical**: More than 20 failed jobs indicates serious problems.
-
-#### 6. Job Completion Rate
-Calculates the percentage of jobs that completed successfully in the last hour.
-
-**Warning**: Less than 95% completion rate indicates issues.
-
-**Critical**: Less than 80% completion rate indicates serious problems.
-
-#### 7. Stuck Sites
-Identifies sites that have been in progress for more than 2 hours without completing.
-
-**Warning**: Sites stuck in progress may have failed jobs or infinite loops.
-
-### Example Output
-
-#### Healthy System
+### Check Worker Status
 
 ```bash
-$ clerk health
+# List running workers
+ps aux | grep "clerk worker"
 
-===================
-Clerk Health Check
-===================
-
-✓ Redis: Connected
-✓ PostgreSQL: Connected
-
-Queue Depths:
-  high: 0
-  fetch: 2
-  ocr: 45
-  compilation: 1
-  extraction: 3
-  deploy: 0
-
-Workers:
-  Total: 12
-  Active: 8
-  Busy: 5
-  Idle: 7
-
-✓ Failed jobs (24h): 0
-✓ Job completion rate (1h): 100.0%
-✓ No sites stuck in progress
-
-Status: ✓ Healthy
+# Expected: One or more clerk worker processes
 ```
 
-#### Degraded System
+### Check Queue Depths
 
 ```bash
-$ clerk health
-
-===================
-Clerk Health Check
-===================
-
-✓ Redis: Connected
-✓ PostgreSQL: Connected
-
-Queue Depths:
-  high: 5
-  fetch: 150 ⚠ (threshold: 50)
-  ocr: 350 ⚠ (threshold: 500)
-  compilation: 12
-  extraction: 8
-  deploy: 2
-
-Workers:
-  Total: 4
-  Active: 4
-  Busy: 4
-  Idle: 0 ⚠
-
-⚠ Failed jobs (24h): 12
-✓ Job completion rate (1h): 92.5%
-⚠ Sites stuck in progress (2): example.civic.band, test.civic.band
-
-Status: ⚠ Degraded
-
-$ echo $?
-1
+redis-cli LLEN rq:queue:fetch
+redis-cli LLEN rq:queue:ocr
+redis-cli LLEN rq:queue:compilation
+redis-cli LLEN rq:queue:deploy
+redis-cli LLEN rq:queue:failed
 ```
 
-#### Unhealthy System
+If queues are growing and workers are running, your system is catching up. If queues keep growing, you may need more workers.
+
+## Queue Monitoring
+
+### View Queue Depths
 
 ```bash
-$ clerk health
-
-===================
-Clerk Health Check
-===================
-
-✗ Redis: Connection refused
-✓ PostgreSQL: Connected
-
-Queue Depths:
-  Cannot check - Redis unavailable
-
-Workers:
-  Cannot check - Redis unavailable
-
-✗ Failed jobs (24h): Unable to check
-✗ Job completion rate (1h): Unable to check
-✗ Sites stuck in progress: Unable to check
-
-Status: ✗ Unhealthy
-
-$ echo $?
-2
+# Watch queue depths in real-time
+watch -n 2 "echo 'Fetch:' && redis-cli LLEN rq:queue:fetch && echo 'OCR:' && redis-cli LLEN rq:queue:ocr && echo 'Compilation:' && redis-cli LLEN rq:queue:compilation && echo 'Failed:' && redis-cli LLEN rq:queue:failed"
 ```
 
-### JSON Output
-
-The `--json` flag outputs structured JSON for integration with monitoring systems:
+### List Jobs in Queue
 
 ```bash
-$ clerk health --json
+# Show first 10 jobs in fetch queue
+redis-cli LRANGE rq:queue:fetch 0 10
+
+# Show all failed jobs
+redis-cli LRANGE rq:queue:failed 0 -1
 ```
 
-```json
-{
-  "status": "healthy",
-  "exit_code": 0,
-  "checks": {
-    "redis": {
-      "status": "ok",
-      "message": "Connected"
-    },
-    "postgresql": {
-      "status": "ok",
-      "message": "Connected"
-    },
-    "queue_depths": {
-      "high": 0,
-      "fetch": 2,
-      "ocr": 45,
-      "compilation": 1,
-      "extraction": 3,
-      "deploy": 0,
-      "warnings": []
-    },
-    "workers": {
-      "total": 12,
-      "active": 8,
-      "busy": 5,
-      "idle": 7,
-      "warnings": []
-    },
-    "failed_jobs_24h": {
-      "count": 0,
-      "status": "ok"
-    },
-    "completion_rate_1h": {
-      "rate": 100.0,
-      "status": "ok"
-    },
-    "stuck_sites": {
-      "count": 0,
-      "sites": [],
-      "status": "ok"
-    }
-  }
-}
-```
-
-### Integration with Monitoring Systems
-
-#### Nagios/Icinga
+### Check Job Details
 
 ```bash
-# /etc/nagios/commands.cfg
-define command {
-    command_name check_clerk_health
-    command_line /usr/local/bin/clerk health
-}
+# Get job details (requires job ID from queue listing)
+redis-cli GET rq:job:JOB_ID
 ```
 
-#### Prometheus + Alertmanager
+## Worker Monitoring
 
-Create a script that exports metrics:
+### Monitor Worker Processes
+
+```bash
+# List all worker processes with CPU/memory
+ps aux | grep "clerk worker" | grep -v grep
+
+# Monitor resource usage in real-time
+top -p $(pgrep -f "clerk worker" | tr '\n' ',')
+```
+
+### Check Worker Registration
+
+```bash
+# List registered workers in Redis
+redis-cli KEYS "rq:worker:*"
+
+# Get worker details
+redis-cli GET "rq:worker:*worker-name*"
+```
+
+## Database Health
+
+### Check Site Status
+
+Using SQLite:
+
+```bash
+# Count total sites
+sqlite3 civic.db "SELECT COUNT(*) FROM sites;"
+
+# List sites by status
+sqlite3 civic.db "SELECT subdomain, status, last_updated FROM sites ORDER BY last_updated DESC;"
+
+# Check sites stuck in progress (not updated in 2+ hours)
+sqlite3 civic.db "SELECT subdomain, status, last_updated FROM sites WHERE last_updated < datetime('now', '-2 hours');"
+```
+
+Using PostgreSQL (if configured):
+
+```bash
+# Count total sites
+psql $DATABASE_URL -c "SELECT COUNT(*) FROM sites;"
+
+# List sites by status
+psql $DATABASE_URL -c "SELECT subdomain, status, last_updated FROM sites ORDER BY last_updated DESC;"
+
+# Check sites stuck in progress (not updated in 2+ hours)
+psql $DATABASE_URL -c "SELECT subdomain, status, last_updated FROM sites WHERE last_updated < NOW() - INTERVAL '2 hours';"
+```
+
+### Verify Pipeline Progression
+
+SQLite:
+```bash
+sqlite3 civic.db "SELECT status, COUNT(*) FROM sites GROUP BY status;"
+```
+
+PostgreSQL:
+```bash
+psql $DATABASE_URL -c "SELECT status, COUNT(*) FROM sites GROUP BY status;"
+```
+
+## Monitoring Patterns
+
+### Real-Time Pipeline Status
 
 ```bash
 #!/bin/bash
-# /usr/local/bin/clerk-health-exporter.sh
+# continuous-monitor.sh - Monitor pipeline every 5 seconds
 
-clerk health --json | jq -r '
-  .checks.queue_depths | to_entries[] |
-  "clerk_queue_depth{queue=\"\(.key)\"} \(.value)"
-'
+while true; do
+  clear
+  echo "=== Clerk Pipeline Status ==="
+  echo "Time: $(date)"
+  echo ""
+  echo "=== Queue Depths ==="
+  echo -n "Fetch: "
+  redis-cli LLEN rq:queue:fetch
+  echo -n "OCR: "
+  redis-cli LLEN rq:queue:ocr
+  echo -n "Compilation: "
+  redis-cli LLEN rq:queue:compilation
+  echo -n "Deploy: "
+  redis-cli LLEN rq:queue:deploy
+  echo -n "Failed: "
+  redis-cli LLEN rq:queue:failed
+  echo ""
+  echo "=== Workers ==="
+  ps aux | grep "clerk worker" | grep -v grep | wc -l
+  echo ""
+  echo "=== Recent Sites ==="
+  sqlite3 civic.db "SELECT subdomain, status, last_updated FROM sites ORDER BY last_updated DESC LIMIT 5;" 2>/dev/null || echo "Database unavailable"
+  sleep 5
+done
 ```
 
-#### Cron-based Monitoring
+Run it with:
+```bash
+bash continuous-monitor.sh
+```
+
+### Alert on Queue Growth
 
 ```bash
-# Check health every 5 minutes, alert on failure
-*/5 * * * * clerk health || /usr/local/bin/alert-on-clerk-failure.sh
+#!/bin/bash
+# alert-on-queue-growth.sh - Alert if queues exceed thresholds
+
+FETCH_QUEUE=$(redis-cli LLEN rq:queue:fetch)
+OCR_QUEUE=$(redis-cli LLEN rq:queue:ocr)
+FAILED_QUEUE=$(redis-cli LLEN rq:queue:failed)
+
+if [ $FETCH_QUEUE -gt 100 ]; then
+  echo "⚠️  High fetch queue depth: $FETCH_QUEUE"
+fi
+
+if [ $OCR_QUEUE -gt 500 ]; then
+  echo "⚠️  High OCR queue depth: $OCR_QUEUE"
+fi
+
+if [ $FAILED_QUEUE -gt 10 ]; then
+  echo "⚠️  Failed jobs detected: $FAILED_QUEUE"
+fi
 ```
 
-## Job Completion Verification
+## Monitoring in Production
 
-As of Phase 1 resilience improvements, all worker jobs now include completion verification:
+### With systemd
 
-### Fetch Stage Verification
-- Warns if no PDFs were downloaded
-- Logs directory existence for debugging
+```bash
+# Log jobs to journald
+journalctl -u clerk-worker-* -f
 
-### OCR Completion Verification
-- Verifies text files exist before proceeding to compilation
-- Fails fast if OCR produced no output
+# Check worker status
+systemctl --user status clerk-worker-*
+```
 
-### Database Compilation Verification
-- Verifies meetings.db file was created
-- Verifies meetings.db contains tables (not empty)
-- Verifies page count was updated in PostgreSQL
-- Warns if page count is 0 after update
+### With Log Files
 
-### Deployment Verification
-- Verifies sites.db was created by post_deploy hook
-- Warns if sites.db is missing
-- Verifies site status is "deployed" in database
-- Warns if status is incorrect
+If running workers with output redirection (optional):
 
-All verification failures are logged with structured context including subdomain, run_id, and stage for easy debugging.
+```bash
+# Start workers with output redirection
+clerk worker fetch > logs/worker-fetch.log 2>&1 &
+
+# Monitor worker output
+tail -f logs/worker-fetch.log
+
+# Count errors in logs
+grep -c "ERROR" logs/worker-fetch.log
+```
+
+### With Cron
+
+```bash
+# Check health every 5 minutes
+*/5 * * * * cd /path/to/clerk && (redis-cli LLEN rq:queue:failed > /tmp/clerk-failed-jobs.txt) 2>&1
+
+# Alert if too many failed jobs
+*/5 * * * * [ $(cat /tmp/clerk-failed-jobs.txt) -gt 20 ] && /usr/local/bin/send-alert.sh "Clerk: too many failed jobs"
+```
 
 ## Troubleshooting
 
 ### High Queue Depths
 
-If queue depths are consistently high:
+If queue depths are growing:
 
-1. **Scale workers horizontally**: Add more worker processes or machines
-2. **Check worker logs**: Look for slow or failing jobs
-3. **Profile jobs**: Identify bottlenecks in the pipeline
+1. **Check worker processes**: `ps aux | grep "clerk worker"`
+2. **Check worker logs**: Look for errors or crashes
+3. **Check Redis**: `redis-cli ping` should return PONG
+4. **Add workers**: Start more worker processes
 
 ### Failed Jobs
 
-If you see many failed jobs:
+If you see failed jobs:
 
-1. **Check job logs**: `clerk logs --failed`
-2. **Retry failed jobs**: Jobs with transient failures can be retried
-3. **Fix root cause**: Address underlying issues (network, permissions, etc.)
+```bash
+# View failed job IDs
+redis-cli LRANGE rq:queue:failed 0 -1
+
+# Get details of a failed job
+redis-cli GET rq:job:JOB_ID
+
+# Check worker output (if running in foreground or tailed to file)
+# Worker output is JSON-formatted to stdout/stderr
+```
 
 ### Stuck Sites
 
-If sites are stuck in progress:
+If sites are in progress for too long:
 
-1. **Check job status**: `clerk status --subdomain example.civic.band`
-2. **Check worker logs**: Look for errors or infinite loops
-3. **Check queue**: Verify jobs aren't stuck in queue
-4. **Manual intervention**: May need to reset site progress or retry jobs
+SQLite:
+```bash
+sqlite3 civic.db "SELECT subdomain, status, last_updated FROM sites WHERE status != 'deployed' AND last_updated < datetime('now', '-2 hours');"
+```
+
+PostgreSQL:
+```bash
+psql $DATABASE_URL -c "SELECT subdomain, status, last_updated FROM sites WHERE status != 'deployed' AND last_updated < NOW() - INTERVAL '2 hours';"
+```
+
+Check logs for the affected sites and manually retry if needed.
 
 ### No Idle Workers
 
 If all workers are busy:
 
-1. **Check job duration**: Are jobs taking longer than expected?
-2. **Scale workers**: Add more worker capacity
-3. **Optimize jobs**: Profile and optimize slow operations
+1. Check if jobs are slow: `top` or `ps aux | grep "clerk worker"`
+2. Add more workers: Start additional `clerk worker` processes
+3. Optimize slow jobs: Profile and optimize the bottleneck operation
 
 ## See Also
 
-- [Troubleshooting Workers](troubleshooting-workers.md) - Worker-specific issues
 - [Task Queue Guide](task-queue.md) - Understanding the queue system
+- [Troubleshooting](../setup/troubleshooting.md) - Debugging issues

--- a/docs/user-guide/troubleshooting-workers.md
+++ b/docs/user-guide/troubleshooting-workers.md
@@ -64,58 +64,76 @@ which clerk
 The worker runs from a specific working directory that must contain the `.env` file.
 
 **How to check:**
-Look at the plist file:
 ```bash
-cat ~/Library/LaunchAgents/com.civicband.clerk.worker.fetch.1.plist
-# Check the <key>WorkingDirectory</key> value
+# Verify you're in the correct directory
+pwd
+# Check if .env exists
+ls -la .env
 ```
 
 **How to fix:**
-- Ensure the working directory exists
-- Ensure `.env` file is in that directory
-- Re-run the install script from the correct directory
+- Run clerk from the directory containing your `.env` file
+- Ensure `.env` file is readable: `cat .env`
 
-## Diagnostic Command
+## Diagnostic Steps
 
-Run the diagnostic command to identify the issue:
+To identify worker issues:
+
+1. **Check if workers are running:**
+   ```bash
+   ps aux | grep "clerk worker"
+   ```
+
+2. **Try running a worker manually to see the error:**
+   ```bash
+   cd /path/to/clerk
+   clerk worker fetch
+   ```
+
+3. **Check Redis connection:**
+   ```bash
+   redis-cli ping
+   # Should return: PONG
+   ```
+
+4. **Check database connection:**
+   
+   For SQLite (default):
+   ```bash
+   sqlite3 civic.db "SELECT 1;"
+   ```
+   
+   For PostgreSQL:
+   ```bash
+   psql $DATABASE_URL -c "SELECT 1;"
+   ```
+
+## Checking Worker Output
+
+Workers output JSON-formatted logs to stdout/stderr:
 
 ```bash
-clerk diagnose-workers
-```
+# If running workers in a terminal, view logs there
+# For background processes, redirect to a file when starting:
+clerk worker fetch > /tmp/clerk-worker-fetch.log 2>&1 &
 
-This will check:
-1. `.env` file existence
-2. Clerk executable
-3. Redis connection
-4. Log directory and recent errors
-5. Plist file validity
-6. Manual worker execution
-
-## Checking Worker Logs
-
-Worker logs are stored in `~/.clerk/logs/`:
-
-```bash
-# View error logs
-tail -f ~/.clerk/logs/clerk-worker-fetch-1.error.log
-
-# View stdout logs
-tail -f ~/.clerk/logs/clerk-worker-fetch-1.log
+# Then tail the log:
+tail -f /tmp/clerk-worker-fetch.log
 ```
 
 ## Manual Worker Testing
 
-Test a worker manually to see the actual error:
+Test a worker manually to see any errors:
 
 ```bash
 cd /path/to/clerk
 source .env
 
-# Try running a worker
+# Try running a worker in burst mode (exits when queues empty)
 clerk worker fetch --burst
 ```
 
-This will show you the actual error message that's preventing the worker from starting.
+This will show you any error messages that prevent the worker from starting or processing jobs.
 
 ## Common Error Messages
 
@@ -135,34 +153,34 @@ This will show you the actual error message that's preventing the worker from st
 - **Cause:** Clerk executable doesn't have execute permissions
 - **Fix:** `chmod +x /path/to/clerk`
 
-## Fixing and Reloading
+## Fixing and Restarting
 
 After fixing the issue:
 
 ```bash
-# Uninstall workers
-clerk uninstall-workers
+# Stop the worker
+pkill -f "clerk worker fetch"
 
 # Fix the issue (start Redis, fix .env, etc.)
 
-# Reinstall workers (run from directory with .env)
-clerk install-workers
+# Restart the worker
+clerk worker fetch &
 ```
 
 ## Verifying Success
 
-After installation, verify workers are running:
+After starting workers, verify they are running:
 
 ```bash
 # Check worker status
-launchctl list | grep com.civicband.clerk.worker
+ps aux | grep "clerk worker"
 
-# Should show workers with PIDs (not just "-")
+# Should show running worker processes
 # Example good output:
-# 12345  0  com.civicband.clerk.worker.fetch.1
-# 12346  0  com.civicband.clerk.worker.fetch.2
+# user  12345  0.5  2.3  ... clerk worker fetch
+# user  12346  0.5  2.3  ... clerk worker ocr
 
-# Check for errors in logs
-ls -lh ~/.clerk/logs/*.error.log
-# Error log files should be 0 bytes if no errors
+# Check that jobs are being processed
+redis-cli LLEN rq:queue:fetch
+# Should return 0 or decreasing number
 ```

--- a/src/clerk/fetcher.py
+++ b/src/clerk/fetcher.py
@@ -1191,11 +1191,11 @@ def _ocr_with_paddleocr(image_path: Path) -> str:
     """
     try:
         from paddleocr import PaddleOCR  # pyright: ignore[reportMissingImports]
-    except ImportError:
+    except ImportError as err:
         raise ImportError(
             "PaddleOCR backend requires the 'paddleocr' package. "
             "Install with: pip install paddleocr"
-        )
+        ) from err
 
     # Initialize PaddleOCR with CPU-friendly settings
     # use_angle_cls: Enable text orientation classification


### PR DESCRIPTION
resolves #147

Remove references to unimplemented CLI commands (clerk health, clerk status, clerk install-workers, clerk diagnose-workers) and replace with simpler manual approaches using redis-cli, shell tools, and standard process managers.

- SQLite is now the default database; PostgreSQL is production-only
- Workers are started manually with `clerk worker <type>` commands
- Queue monitoring uses redis-cli inspection instead of clerk status
- Troubleshooting uses ps aux, redis-cli, and log inspection
- Remove non-existent guide references from navigation

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist

<!--- If existing, please state which site -->
New site, or existing?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the CivicBand Code of Conduct
- [x] I will abide by the CivicBand Contributor Guide
- [x] This PR was generated or assisted using an AI tool
<!-- AI assistance is allowed, but must be marked -->
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Haiku 4.5 
