### PR TITLE
Add PR Timeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,6 +284,10 @@ logfire auth
 - Run `just format` and `just lint-fix` manually
 - Commit the formatted code
 
+### After Submitting PRs
+
+One of the maintainers will review your PR at our earliest convenience. We might have follow-up questions, which we'll post either as a comment on the PR (for overall/general feedback) or using the GitHub reviews workflow (for line-specific feedback). If we don't get a response to questions about your PR within a month, we'll close the PR to avoid stale PR buildup. You should feel free to reopen it when you come back, though! 
+
 ## Getting Help
 
 - **Issues**: https://github.com/civicband/clerk/issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,6 +288,12 @@ logfire auth
 
 One of the maintainers will review your PR at our earliest convenience. We might have follow-up questions, which we'll post either as a comment on the PR (for overall/general feedback) or using the GitHub reviews workflow (for line-specific feedback). If we don't get a response to questions about your PR within a month, we'll close the PR to avoid stale PR buildup. You should feel free to reopen it when you come back, though! 
 
+- Be respectful and inclusive
+- Focus on constructive feedback
+- Help others learn and grow
+
+Thank you for contributing to Clerk! 🎉
+
 ## Getting Help
 
 - **Issues**: https://github.com/civicband/clerk/issues
@@ -296,8 +302,5 @@ One of the maintainers will review your PR at our earliest convenience. We might
 
 ## Code of Conduct
 
-- Be respectful and inclusive
-- Focus on constructive feedback
-- Help others learn and grow
+We use Civic Band's organization-level [Code of Conduct](https://github.com/civicband/.github/blob/main/CODE_OF_CONDUCT.md).
 
-Thank you for contributing to Clerk! 🎉


### PR DESCRIPTION
Resolves issue #152 by adding information about the PR timeline to the CONTRIBUTORS.md. 

This change creates a new "After submitting a PR" section to have the PR timeline in. The information previously listed under "Code of Conduct" that was not the code of conduct makes more sense there, so I also moved that and added a reference to the actual Code of Conduct in the "Code of Conduct" section.

Fixes #152 

## PR Checklist

New site, or existing? N/A

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X ] I will abide by the CivicBand Code of Conduct
- [ X ] I will abide by the CivicBand Contributor Guide
- [ ] This PR was generated or assisted using an AI tool
