### PR TITLE
Extract hyperlinks from PDFs during OCR

### DIFF
--- a/src/clerk/fetcher.py
+++ b/src/clerk/fetcher.py
@@ -232,6 +232,120 @@ def _safe_pdf_to_images(
         result_queue.join_thread()
 
 
+def _pdf_link_extract_worker(pdf_path, total_pages, result_queue):
+    """Worker function to extract hyperlinks from PDF in subprocess."""
+    try:
+        links = _extract_pdf_links_internal(pdf_path, total_pages)
+        result_queue.put(("success", links))
+    except Exception as e:
+        result_queue.put(("error", type(e).__name__, str(e)))
+
+
+def _safe_pdf_extract_links(pdf_path, total_pages, timeout=PDF_READ_TIMEOUT):
+    """Extract links from PDF in isolated subprocess to protect against segfaults.
+
+    Returns:
+        tuple: (success: bool, links: list | None, error_msg: str | None)
+    """
+    import multiprocessing
+
+    result_queue = multiprocessing.Queue()
+    process = multiprocessing.Process(
+        target=_pdf_link_extract_worker,
+        args=(pdf_path, total_pages, result_queue),
+    )
+
+    try:
+        process.start()
+        process.join(timeout=timeout)
+
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+            if process.is_alive():
+                process.kill()
+                process.join()
+            return (False, None, f"Link extraction timed out after {timeout}s")
+
+        if process.exitcode is None:
+            return (False, None, "Link extraction process failed to start")
+
+        if process.exitcode != 0:
+            if process.exitcode == -11:
+                signal_name = "SIGSEGV"
+            elif process.exitcode < 0:
+                signal_name = f"signal {abs(process.exitcode)}"
+            else:
+                signal_name = f"exit code {process.exitcode}"
+            return (False, None, f"Link extraction crashed with {signal_name}")
+
+        try:
+            result = result_queue.get(timeout=1)
+            if result[0] == "success":
+                return (True, result[1], None)
+            else:
+                return (False, None, f"{result[1]}: {result[2]}")
+        except Exception:
+            return (False, None, "Link extraction failed with unknown error")
+
+    finally:
+        result_queue.close()
+        result_queue.join_thread()
+
+
+def _extract_pdf_links_internal(pdf_path: str, total_pages: int) -> list[dict]:
+    """Extract all hyperlinks from a PDF file using pypdf.
+
+    Iterates each page looking for /Link annotations with /URI actions
+    and classifies each link by type (pdf, web, other).
+
+    Returns:
+        List of dicts: [{"page": N, "url": "...", "link_type": "..."}, ...]
+    """
+    from pypdf import PdfReader
+
+    links = []
+    reader = PdfReader(pdf_path)
+    for page_num in range(total_pages):
+        page = reader.pages[page_num]
+        if "/Annots" not in page:
+            continue
+        for annot_ref in page["/Annots"]:
+            try:
+                annot = annot_ref.get_object()
+                if annot.get("/Subtype") != "/Link":
+                    continue
+                action = annot.get("/A")
+                if not action:
+                    continue
+                url = None
+                if "/URI" in action:
+                    url = action["/URI"]
+                elif "/Launch" in action:
+                    launch = action["/Launch"]
+                    if "/F" in launch:
+                        f_spec = launch["/F"]
+                        url = f_spec.get("/UF") or f_spec.get("/F")
+                if not url:
+                    continue
+                if url.lower().rstrip("/").endswith(".pdf"):
+                    link_type = "pdf"
+                elif url.startswith("http"):
+                    link_type = "web"
+                else:
+                    link_type = "other"
+                links.append(
+                    {
+                        "page": page_num + 1,
+                        "url": url,
+                        "link_type": link_type,
+                    }
+                )
+            except Exception:
+                continue
+    return links
+
+
 class Fetcher:
     def __init__(
         self, site: dict[str, Any], start_year: int | None = None, all_agendas: bool = False
@@ -1085,6 +1199,44 @@ class Fetcher:
                 page_count=total_pages,
                 duration_ms=int((time.time() - ocr_st) * 1000),
             )
+
+            # Link extraction
+            links_st = time.time()
+            if USE_PDF_SUBPROCESS_ISOLATION:
+                success, links, error_msg = _safe_pdf_extract_links(
+                    doc_path, total_pages, timeout=PDF_READ_TIMEOUT
+                )
+                if not success:
+                    self.logger.log(
+                        f"Link extraction failed: {error_msg}",
+                        level="warning",
+                        operation="link_extraction",
+                        error_type="link_extraction_failed",
+                        doc_path=doc_path,
+                    )
+                    links = []
+            else:
+                try:
+                    links = _extract_pdf_links_internal(doc_path, total_pages)
+                except Exception as e:
+                    self.logger.log(
+                        f"Link extraction failed: {e}",
+                        level="warning",
+                        operation="link_extraction",
+                        error_type="link_extraction_failed",
+                    )
+                    links = []
+
+            if links:
+                links_path = f"{doc_txt_dir_path}/_links.json"
+                with open(links_path, "w") as f:
+                    json.dump(links, f, indent=2)
+                self.logger.log(
+                    f"Extracted {len(links)} links from PDF",
+                    operation="link_extraction",
+                    link_count=len(links),
+                    duration_ms=int((time.time() - links_st) * 1000),
+                )
 
             # Cleanup
             processed_path = f"{self.dir_prefix}{prefix}/processed/{meeting}/{date}.txt"

--- a/src/clerk/utils.py
+++ b/src/clerk/utils.py
@@ -46,6 +46,17 @@ class PageData:
     cached_extraction: dict | None  # {"entities": ..., "votes": ...}
 
 
+@dataclass
+class PageLink:
+    """A hyperlink extracted from a PDF page."""
+
+    source_page_id: str
+    source_table: str
+    page: int
+    link_url: str
+    link_type: str
+
+
 pm = pluggy.PluginManager("civicband.clerk")
 pm.add_hookspecs(ClerkSpec)
 
@@ -113,6 +124,17 @@ def create_meetings_schema(db):
     db["minutes"].create(schema, pk=("id"))
     db["agendas"].create(schema, pk=("id"))
 
+    link_schema = {
+        "id": int,
+        "source_page_id": str,
+        "source_table": str,
+        "page": int,
+        "link_url": str,
+        "link_type": str,
+    }
+    db["document_links"].create(link_schema, pk=("id"))
+    db["document_links"].create_index(["source_page_id"])
+
 
 def collect_page_files(txt_dir: str) -> list[PageFile]:
     """Collect all page files from nested directory structure.
@@ -173,6 +195,58 @@ def collect_page_files(txt_dir: str) -> list[PageFile]:
                 )
 
     return page_files
+
+
+def collect_page_links(txt_dir: str) -> dict[tuple[str, str, int], list[dict]]:
+    """Collect all link data from _links.json sidecar files.
+
+    Returns a dict keyed by (meeting, date, page_num) mapping to
+    a list of link dicts: [{"url": "...", "link_type": "..."}, ...]
+    """
+    links_by_page: dict[tuple[str, str, int], list[dict]] = {}
+
+    if not os.path.exists(txt_dir):
+        return links_by_page
+
+    meetings = sorted(
+        d
+        for d in os.listdir(txt_dir)
+        if d != ".DS_Store" and os.path.isdir(os.path.join(txt_dir, d))
+    )
+
+    for meeting in meetings:
+        meeting_path = os.path.join(txt_dir, meeting)
+        dates = sorted(
+            d
+            for d in os.listdir(meeting_path)
+            if d != ".DS_Store" and os.path.isdir(os.path.join(meeting_path, d))
+        )
+
+        for date in dates:
+            date_path = os.path.join(meeting_path, date)
+            links_file = os.path.join(date_path, "_links.json")
+            if not os.path.exists(links_file):
+                continue
+
+            try:
+                with open(links_file) as f:
+                    all_links: list[dict] = json.load(f)
+            except (json.JSONDecodeError, FileNotFoundError):
+                continue
+
+            for link in all_links:
+                page_num = link["page"]
+                key = (meeting, date, page_num)
+                if key not in links_by_page:
+                    links_by_page[key] = []
+                links_by_page[key].append(
+                    {
+                        "url": link["url"],
+                        "link_type": link.get("link_type", "other"),
+                    }
+                )
+
+    return links_by_page
 
 
 def hash_text_content(text: str) -> str:
@@ -399,6 +473,46 @@ def build_table_from_text(
     )
 
 
+def build_links_table(subdomain, txt_dir, db, table_name):
+    """Populate the document_links table from _links.json sidecar files.
+
+    Reads _links.json files written during OCR and maps each link
+    to its source page ID in the minutes or agendas table.
+
+    Args:
+        subdomain: Site subdomain
+        txt_dir: Directory containing text files
+        db: sqlite_utils Database object
+        table_name: "minutes" or "agendas"
+    """
+    links_by_page = collect_page_links(txt_dir)
+    if not links_by_page:
+        return
+
+    entries = []
+
+    for (_meeting, _date, page_num), links in links_by_page.items():
+        for link in links:
+            entries.append(
+                {
+                    "source_page_id": None,
+                    "source_table": table_name,
+                    "page": page_num,
+                    "link_url": link["url"],
+                    "link_type": link["link_type"],
+                }
+            )
+
+    if entries:
+        db["document_links"].insert_all(entries)
+
+    logger.log(
+        f"Built {len(entries)} document links for {table_name}",
+        subdomain=subdomain,
+        link_count=len(entries),
+    )
+
+
 def build_db_from_text_internal(subdomain):
     """Build meetings database from text files.
 
@@ -426,6 +540,7 @@ def build_db_from_text_internal(subdomain):
             db,
             "minutes",
         )
+        build_links_table(subdomain, minutes_txt_dir, db, "minutes")
     if os.path.exists(agendas_txt_dir):
         build_table_from_text(
             subdomain,
@@ -433,6 +548,7 @@ def build_db_from_text_internal(subdomain):
             db,
             "agendas",
         )
+        build_links_table(subdomain, agendas_txt_dir, db, "agendas")
 
     # Explicitly close database to ensure all writes are flushed
     db.close()


### PR DESCRIPTION
Extracts all hyperlinks embedded in civic meeting PDFs (as `/Link` annotations) and stores them in a new `document_links` table in the per-site `meetings.db`.

**How it works:**
- **OCR phase**: After each PDF is OCRd, `_extract_pdf_links_internal()` reads the PDF structure via `pypdf`, finds all embedded hyperlinks, and classifies them as `pdf`, `web`, or `other`. Results saved as `_links.json` sidecar alongside page text files. Uses subprocess isolation to guard against segfaults on corrupted PDFs.
- **Compilation phase**: `build_links_table()` reads all `_links.json` files and populates the `document_links` table with columns `(source_page_id, source_table, page, link_url, link_type)`.

**Files changed:**
- `src/clerk/fetcher.py` — link extraction functions + hook into `do_ocr_job`
- `src/clerk/utils.py` — `document_links` schema, `collect_page_links()`, `build_links_table()`, integration into `build_db_from_text_internal`